### PR TITLE
Enable import SwiftUI header for SkipFuse apps

### DIFF
--- a/Sources/SkipBuild/Commands/InitCommand.swift
+++ b/Sources/SkipBuild/Commands/InitCommand.swift
@@ -405,13 +405,15 @@ struct PackageModule {
     var moduleName: String
     var repositoryVersion: String?
     var dependencies: [PackageModule]
+    var condition: String?
 
-    init(organizationName: String? = nil, repositoryName: String? = nil, repositoryVersion: String? = nil, moduleName: String, dependencies: [PackageModule] = []) {
+    init(organizationName: String? = nil, repositoryName: String? = nil, repositoryVersion: String? = nil, moduleName: String, dependencies: [PackageModule] = [], condition: String? = nil) {
         self.organizationName = organizationName
         self.repositoryName = repositoryName
         self.repositoryVersion = repositoryVersion
         self.moduleName = moduleName
         self.dependencies = dependencies
+        self.condition = condition
     }
 
     init(parse: String) throws {
@@ -421,6 +423,7 @@ struct PackageModule {
         self.repositoryVersion = nil
         self.organizationName = nil
         self.dependencies = []
+        self.condition = nil
         for dep in parts.dropFirst() {
             // parse PlaygroundModel:skiptools/skip-model/SkipModel:skip-foundation@0.1.0/SkipFoundation
             var depParts = dep.split(separator: "/").map(\.description)

--- a/Sources/SkipBuild/SkipProject.swift
+++ b/Sources/SkipBuild/SkipProject.swift
@@ -1209,6 +1209,7 @@ struct TestData : Codable, Hashable {
                 // add implicit dependency on SkipUI (for app target), SkipModel, and SkipFoundation, based in their position in the chain
                 if isAppModule {
                     if isNativeAppModule {
+                        modDeps.append(PackageModule(repositoryName: "skip-fuse-ui", moduleName: "SwiftUI", condition: ".when(platforms: [.android])"))
                         modDeps.append(PackageModule(repositoryName: "skip-fuse-ui", moduleName: "SkipFuseUI"))
                     } else {
                         modDeps.append(PackageModule(repositoryName: "skip-ui", moduleName: "SkipUI"))
@@ -1263,7 +1264,11 @@ struct TestData : Codable, Hashable {
                     if !packageDependencies.contains(packDep) {
                         packageDependencies.append(packDep)
                     }
-                    let dep = ".product(name: \"\(modDep.moduleName)\", package: \"\(repoName)\")"
+                    var dep = ".product(name: \"\(modDep.moduleName)\", package: \"\(repoName)\""
+                    if let condition = modDep.condition {
+                        dep += ", condition: \(condition)"
+                    }
+                    dep += ")"
                     if !skipModuleDeps.contains(dep) {
                         skipModuleDeps.append(dep)
                     }
@@ -2235,7 +2240,7 @@ New features and better performance.
         }
 
         let isNativeAppModule = nativeMode.contains(.nativeApp)
-        let swiftUIImport = isNativeAppModule ? "import SkipFuseUI" : "import SwiftUI"
+        let swiftUIImport = "import SwiftUI"
         let osLogImport = isNativeAppModule ? "import SkipFuse" : "import OSLog"
         // explicitly bridge the public app functions that need to be accessed from Main.kt
         let skipBridge = isNativeAppModule ? "/* SKIP @bridge */" : ""

--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeToKotlinVisitor.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeToKotlinVisitor.swift
@@ -18,7 +18,7 @@ final class KotlinBridgeToKotlinVisitor {
         self.options = options
         self.translator = translator
         self.codebaseInfo = codebaseInfo
-        self.includesUI = translator.syntaxTree.root.statements.compactMap({ $0 as? ImportDeclaration }).contains { $0.modulePath.first == "SkipSwiftUI"  || $0.modulePath.first == "SkipFuseUI" }
+        self.includesUI = translator.syntaxTree.root.statements.compactMap({ $0 as? ImportDeclaration }).contains { $0.modulePath.first == "SwiftUI" || $0.modulePath.first == "SkipSwiftUI" || $0.modulePath.first == "SkipFuseUI" }
     }
 
     func visit() -> [KotlinTransformerOutput] {

--- a/Sources/SkipSyntax/Transpiler.swift
+++ b/Sources/SkipSyntax/Transpiler.swift
@@ -50,6 +50,7 @@ public struct Transpiler {
                     // bubble up to the user because these trees are only used to gather information, and we re-parse
                     // for only bridging below. Look for e.g. '#if SKIP' or '// SKIP @bridge' or Views that auto-bridge
                     var shouldBridge = bridgeSource.content.contains("SKIP")
+                        || bridgeSource.content.contains("SwiftUI")
                         || bridgeSource.content.contains("SkipFuseUI")
                         || bridgeSource.content.contains("SkipSwiftUI")
                         || bridgeSource.content.contains("@Observable")

--- a/Tests/SkipBuildTests/SkipCommandTests.swift
+++ b/Tests/SkipBuildTests/SkipCommandTests.swift
@@ -1134,6 +1134,7 @@ final class SkipCommandTests: XCTestCase {
             targets: [
                 .target(name: "AppModule", dependencies: [
                     "ModelModule",
+                    .product(name: "SwiftUI", package: "skip-fuse-ui", condition: .when(platforms: [.android])),
                     .product(name: "SkipFuseUI", package: "skip-fuse-ui")
                 ], plugins: [.plugin(name: "skipstone", package: "skip")]),
                 .target(name: "ModelModule", dependencies: [
@@ -1243,6 +1244,7 @@ final class SkipCommandTests: XCTestCase {
             ],
             targets: [
                 .target(name: "AppModule", dependencies: [
+                    .product(name: "SwiftUI", package: "skip-fuse-ui", condition: .when(platforms: [.android])),
                     .product(name: "SkipFuseUI", package: "skip-fuse-ui")
                 ], plugins: [.plugin(name: "skipstone", package: "skip")]),
             ]


### PR DESCRIPTION
This PR makes it so SkipFuse apps can just `import SwiftUI` rather than `import SkipFuseUI`. It does require an Android-conditional dependency on skip-fuse-ui's `SwiftUI` target (added in https://github.com/skiptools/skip-fuse-ui/pull/47).

Packages will additionally continue to need to depend on the `SkipFuseUI` product, because the Android-conditional inclusion of SwiftUI means the skipstone plugin wouldn't otherwise run on the `SkipFuseUI` module.