### PR TITLE
Support custom PreferenceKeys

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinMessage.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinMessage.swift
@@ -363,6 +363,10 @@ extension Message {
         return Message(kind: .error, message: "Skip only supports OptionSets that are structs. Change this type to a struct", sourceDerived: sourceDerived, source: source)
     }
 
+    static func kotlinPreferenceKeyDefault(_ sourceDerived: SourceDerived, source: Source) -> Message {
+        return Message(kind: .warning, message: "Skip is unable to determine the default value of this PreferenceKey type. Make sure it declares a static 'defaultValue' property with an explicitly declared type", sourceDerived: sourceDerived, source: source)
+    }
+
     static func kotlinProtocolMemberVisibility(_ sourceDerived: SourceDerived, source: Source) -> Message {
         return Message(kind: .warning, message: "Kotlin does not support protocol members with lower visibility than their declaring protocol. Skip will elevate the visibility of this member, which may cause problems if it exposes internal types", sourceDerived: sourceDerived, source: source)
     }

--- a/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
@@ -147,16 +147,19 @@ private final class TranslateVisitor {
     }
 
     private func translateClassDeclaration(_ classDeclaration: KotlinClassDeclaration) {
-        var environmentKeyIndex: Int? = nil
         for i in 0..<classDeclaration.inherits.count {
             if classDeclaration.inherits[i].isNamed("EnvironmentKey", moduleName: "SwiftUI") {
-                environmentKeyIndex = i
+                translateEnvironmentKey(classDeclaration, inheritsIndex: i)
+                break
+            }
+            if classDeclaration.inherits[i].isNamed("PreferenceKey", moduleName: "SwiftUI") {
+                translatePreferenceKey(classDeclaration, inheritsIndex: i)
                 break
             }
         }
-        guard let environmentKeyIndex else {
-            return
-        }
+    }
+
+    private func translateEnvironmentKey(_ classDeclaration: KotlinClassDeclaration, inheritsIndex: Int) {
         guard let defaultValueDeclaration = classDeclaration.members
             .compactMap({ $0 as? KotlinVariableDeclaration })
             .first(where: { $0.propertyName == "defaultValue" && $0.isStatic }),
@@ -164,14 +167,33 @@ private final class TranslateVisitor {
             classDeclaration.messages.append(.kotlinEnvironmentValuesKeyDefault(classDeclaration, source: translator.syntaxTree.source))
             return
         }
-
-        // Kotlin requires that the key type be public in order to reflect on it from the SkipUI package
-        classDeclaration.modifiers.visibility = .public
-
         defaultValueDeclaration.modifiers.isOverride = true
         defaultValueDeclaration.modifiers.visibility = .public
-        classDeclaration.inherits[environmentKeyIndex] = .named("EnvironmentKey", [defaultValueDeclaration.propertyType])
+
+        classDeclaration.inherits[inheritsIndex] = .named("EnvironmentKey", [defaultValueDeclaration.propertyType])
         classDeclaration.companionInherits.append(.interface(.named("EnvironmentKeyCompanion", [defaultValueDeclaration.propertyType])))
+    }
+
+    private func translatePreferenceKey(_ classDeclaration: KotlinClassDeclaration, inheritsIndex: Int) {
+        guard let defaultValueDeclaration = classDeclaration.members
+            .compactMap({ $0 as? KotlinVariableDeclaration })
+            .first(where: { $0.propertyName == "defaultValue" && $0.isStatic }),
+            defaultValueDeclaration.propertyType != .none else {
+            classDeclaration.messages.append(.kotlinPreferenceKeyDefault(classDeclaration, source: translator.syntaxTree.source))
+            return
+        }
+        defaultValueDeclaration.modifiers.isOverride = true
+        defaultValueDeclaration.modifiers.visibility = .public
+
+        if let reduceDeclaration = classDeclaration.members
+            .compactMap({ $0 as? KotlinFunctionDeclaration })
+            .first(where: { $0.name == "reduce" && $0.isStatic && $0.parameters.count == 2 && $0.parameters[0].externalLabel == "value" && $0.parameters[1].externalLabel == "nextValue" }) {
+            reduceDeclaration.modifiers.isOverride = true
+            reduceDeclaration.modifiers.visibility = .public
+        }
+
+        classDeclaration.inherits[inheritsIndex] = .named("PreferenceKey", [defaultValueDeclaration.propertyType])
+        classDeclaration.companionInherits.append(.interface(.named("PreferenceKeyCompanion", [defaultValueDeclaration.propertyType])))
     }
 
     private func translateConstructorDeclaration(_ functionDeclaration: KotlinFunctionDeclaration) {

--- a/Tests/SkipSyntaxTests/SwiftUITests.swift
+++ b/Tests/SkipSyntaxTests/SwiftUITests.swift
@@ -2165,7 +2165,7 @@ final class SwiftUITests: XCTestCase {
         import skip.ui.*
         import skip.foundation.*
         import skip.model.*
-        class MyKey: EnvironmentKey<String> {
+        internal class MyKey: EnvironmentKey<String> {
 
             companion object: EnvironmentKeyCompanion<String> {
 
@@ -2210,6 +2210,39 @@ final class SwiftUITests: XCTestCase {
             override fun body(): View {
                 return ComposeBuilder { composectx: ComposeContext ->
                     VStack().environment({ it -> EnvironmentValues.shared.setfont(it) }, Font.body).Compose(composectx)
+                }
+            }
+        }
+        """)
+    }
+
+    func testCustomPreferenceKey() async throws {
+        try await check(supportingSwift: baseSupportingSwift, swift: """
+        import SwiftUI
+        struct MyKey: PreferenceKey {
+            static let defaultValue = ""
+            static func reduce(value: inout String, nextValue: () -> String) {
+                value = nextValue()
+            }
+        }
+        """, kotlin: """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.getValue
+        import androidx.compose.runtime.mutableStateOf
+        import androidx.compose.runtime.remember
+        import androidx.compose.runtime.saveable.Saver
+        import androidx.compose.runtime.saveable.rememberSaveable
+        import androidx.compose.runtime.setValue
+
+        import skip.ui.*
+        import skip.foundation.*
+        import skip.model.*
+        internal class MyKey: PreferenceKey<String> {
+
+            companion object: PreferenceKeyCompanion<String> {
+                override val defaultValue = ""
+                override fun reduce(value: InOut<String>, nextValue: () -> String) {
+                    value.value = nextValue()
                 }
             }
         }


### PR DESCRIPTION
This patch also removes the automatic promotion of environment and preference key types to public. It was causing problems and no longer seems necessary.

This patch requires updates to skip-ui. See corresponding skip-ui PR.
