### PR TITLE
Improve build performance of skip android build when run from Xcode

### DIFF
--- a/Sources/SkipBuild/Commands/AndroidCommand.swift
+++ b/Sources/SkipBuild/Commands/AndroidCommand.swift
@@ -161,7 +161,7 @@ fileprivate extension AndroidOperationCommand {
         #else
 
         if outputOptions.verbose {
-            print("running command: \(command.joined(separator: " "))")
+            print("running command: \(env.sorted(by: { $0.key < $1.key }).map { "\($0)='\($1)'" }.joined(separator: " ")) \(command.joined(separator: " "))") // to: &TSCBasic.stderrStream) // stderrStream doesn't show up in Xcode logs
         }
 
         for try await outputLine in Process.streamLines(command: command, environment: env, includeStdErr: true, onExit: { result in
@@ -177,7 +177,7 @@ fileprivate extension AndroidOperationCommand {
                 if !outputOptions.verbose && (
                     // additional filters to to handle warnings raised by the way we replace remote dependencies with their local equivalents
                     outputLine.line.hasSuffix(" is not used by any target") // 'swift': dependency 'swift-system' is not used by any target
-                    || outputLine.line.hasSuffix(" this will be escalated to an error in future versions of SwiftPM.") // '…': '…' dependency on '…' conflicts with dependency on '…' which has the same identity '…'. this will be escalated to an error in future versions of SwiftPM.
+                    || outputLine.line.hasSuffix("will be escalated to an error in future versions of SwiftPM.") // '…': '…' dependency on '…' conflicts with dependency on '…' which has the same identity '…'. this will be escalated to an error in future versions of SwiftPM.
                     || outputLine.line.hasSuffix("unhandled; explicitly declare them as resources or exclude from the target")
                 ) {
                     continue
@@ -201,11 +201,12 @@ fileprivate extension AndroidOperationCommand {
 
     /// Run `swift build` for the given Android architectures, optionally running the test cases on the device or copying all the files to the given `archiveOutputFolder`
     func runSwiftPM(cleanup: Bool? = nil, execute executable: String? = nil, commandEnvironment: [String] = [], defaultArch: AndroidArchArgument, remoteFolder: String? = nil, copy: [String] = [], archiveOutputFolder: URL? = nil, testingLibrary: TestingLibrary?, with out: MessageQueue) async throws {
+        let buildConfig = toolchainOptions.configuration ?? BuildConfiguration.fromEnvironment() ?? .debug
         let packageDir = toolchainOptions.packagePath ?? "."
         let archs = !toolchainOptions.arch.isEmpty ? toolchainOptions.arch : [defaultArch]
         // pick the default architecture based on the current host; for running executables and tests, this will likely be the one that matches an attached emulator, but for an attached device, we don't know (e.g., an x86_64 host may be connecting to an aarch64 device).
 
-        let architectures = archs.flatMap(\.architectures).uniqueElements()
+        let architectures = archs.flatMap({ $0.architectures(configuration: buildConfig) }).uniqueElements()
         for arch in architectures {
             let tc = try buildToolchainConfiguration(for: arch)
 
@@ -220,6 +221,18 @@ fileprivate extension AndroidOperationCommand {
             // which will break the build.
             // So we manually clear the SDKROOT environment variable in case it is set.
             env["SDKROOT"] = nil
+
+            // We also need to clear out any environment variables that may change between runs (like LLBUILD_BUILD_ID='4288622949' LLBUILD_LANE_ID='9' LLBUILD_TASK_ID='31650009000f'), since those will prevent incremental builds from happening and force a complete rebuild each time
+            if env["XCODE_VERSION_MAJOR"] != nil {
+                let permittedEnvironment: Set<String> = [
+                    "PATH", "HOME", "HOMEBREW_PREFIX", "JAVA_HOME", "LANG", "LOGNAME", "PWD", "SHELL", "SWIFTLY_BIN_DIR", "SWIFTLY_HOME_DIR", "TMPDIR", "USER"
+                ]
+                env = env.filter({ (key, value) in
+                    permittedEnvironment.contains(key)
+                    && !key.hasPrefix("SKIP_")
+                    && !key.hasPrefix("ANDROID_") // "ANDROID_HOME", "ANDROID_NDK_HOME", "ANDROID_NDK_ROOT", "ANDROID_NDK", "ANDROID_SERIAL"
+                })
+            }
 
             // manually disable the skipstone plugin from being run again in the derived build; we don't need to transpile and bridge the code a second time, we only need to build the native libraries with the Android toolchain
             //env["SKIP_PLUGIN_DISABLED"] = "1"
@@ -339,7 +352,7 @@ fileprivate extension AndroidOperationCommand {
                 // the output folder is either the scratch path we have specified, or is the default package/.build output directory
                 toolchainOptions.scratchPath ?? (packageDir + "/.build"),
                 arch.target(api: toolchainOptions.androidAPILevel),
-                toolchainOptions.configuration?.rawValue ?? "debug",
+                buildConfig.rawValue,
             ].joined(separator: "/")
 
             let buildOutputFolderURL = URL(fileURLWithPath: buildOutputFolder)
@@ -945,20 +958,20 @@ enum AndroidArchArgument: String, ExpressibleByArgument, CaseIterable {
     case armv7
     case x86_64
 
-    static let exportArchsEnironment = "SKIP_EXPORT_ARCHS"
+    static let exportArchsEnvironment = "SKIP_EXPORT_ARCHS"
 
-    var architectures: [AndroidArch] {
+    func architectures(configuration: BuildConfiguration) -> [AndroidArch] {
         switch self {
         case .automatic:
             // For debug builds, just build for the current architecture.
             // Ideally we would use `ONLY_ACTIVE_ARCH`, but that seems to be always set to "YES" even for Release builds.
             // The "SKIP_EXPORT_ARCHS" is used to pass the flags from `skip export --arch …` through the gradle process, which always exports with "automatic"
-            if let archList = ProcessInfo.processInfo.environment[Self.exportArchsEnironment], !archList.isEmpty {
+            if let archList = ProcessInfo.processInfo.environment[Self.exportArchsEnvironment], !archList.isEmpty {
                 return archList.split(separator: ",").compactMap(String.init).compactMap(AndroidArch.init)
-            } else if ProcessInfo.processInfo.environment["CONFIGURATION"]?.uppercased() == "DEBUG" {
-                return AndroidArchArgument.current.architectures
+            } else if configuration == .release {
+                return AndroidArchArgument.`default`.architectures(configuration: configuration)
             } else {
-                return AndroidArchArgument.`default`.architectures
+                return AndroidArchArgument.current.architectures(configuration: configuration)
             }
         case .current:
             return ProcessInfo.isARM ? [.aarch64] : [.x86_64]

--- a/Sources/SkipBuild/Commands/ExportCommand.swift
+++ b/Sources/SkipBuild/Commands/ExportCommand.swift
@@ -148,7 +148,7 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
 
         if !arch.isEmpty {
             // take the arch flag(s) and set them in the `SKIP_EXPORT_ARCHS` environment, which will be processed by the AndroidCommand when it sees the SkipBridge `--arch automatic` setting
-            env[AndroidArchArgument.exportArchsEnironment] = arch.map(\.rawValue).joined(separator: ",")
+            env[AndroidArchArgument.exportArchsEnvironment] = arch.map(\.rawValue).joined(separator: ",")
         }
 
         let assembleAction = variants == [.debug] ? "assembleDebug" : variants == [.release] ? "assembleRelease" : "assemble"

--- a/Sources/SkipBuild/Commands/GradleCommand.swift
+++ b/Sources/SkipBuild/Commands/GradleCommand.swift
@@ -39,7 +39,7 @@ struct GradleCommand: SkipCommand {
     func run() async throws {
         // when the environment "SKIP_ACTION" is set to "none", completely ignore the gradle launch command; this is to provide backwards compatibility for pre-existing projects that do not have updated Xcode target's Build Phases "Run script" actions.
         // https://github.com/skiptools/skip/issues/408
-        // TODO: should we just handle all the short-circuit envrionment variables here, like SKIP_ZERO, ENABLE_PREVIEWS, and ACTION="insall"?
+        // TODO: should we just handle all the short-circuit environment variables here, like SKIP_ZERO, ENABLE_PREVIEWS, and ACTION="insall"?
         if ProcessInfo.processInfo.environment["SKIP_ACTION"] == "none" {
             print("note: skipping skip due to SKIP_ACTION none")
             return

--- a/Sources/SkipBuild/Commands/InitCommand.swift
+++ b/Sources/SkipBuild/Commands/InitCommand.swift
@@ -201,6 +201,11 @@ let androidBuildFolder = buildFolderName + "/Android"
 /// The build configuration, either `debug` or `release`.
 enum BuildConfiguration : String, ExpressibleByArgument {
     case debug, release
+
+    /// Returns the default value based on the `CONFIGURATION` environment variable.
+    static func fromEnvironment() -> BuildConfiguration? {
+        return BuildConfiguration(rawValue: ProcessInfo.processInfo.environment["CONFIGURATION"]?.lowercased() ?? "")
+    }
 }
 
 extension ToolOptionsCommand where Self : StreamingCommand {


### PR DESCRIPTION
Building native SkipFuse projects has always been very slow because a Skip project like ShowcaseFuse would take upwards of 60 seconds to re-build from Xcode even when nothing changed.

The issue stems from the invocation of `skip android build` by SkipBridge's `skip.yml`, which simply forks `swift build --swift-sdk …` with all the right arguments. `swift build` seems to take the current environment variables into account when determining whether a re-build needs to be performed. This was being triggered every time in Xcode, because there are various "volatile" environment variables like `LLBUILD_BUILD_ID`, `LLBUILD_LANE_ID`, and `LLBUILD_TASK_ID` that will be different each time it is invoked.

This PR checks whether the build is taking place from Xcode (based on the presence of an `XCODE_VERSION_MAJOR` environment), and if so, aggressively trims down the set of environment variables to a known subset. This drastically reduced a clean re-build time to around 10 seconds on my machine, and a re-build time with a single small change to around 30 seconds.