### PR TITLE
Support // SKIP @bridgeMembers

### DIFF
--- a/Sources/SkipBuild/Commands/AndroidCommand.swift
+++ b/Sources/SkipBuild/Commands/AndroidCommand.swift
@@ -1260,6 +1260,7 @@ struct AndroidEmulatorListCommand: MessageCommand, ToolOptionsCommand {
     func listAndroidEmulators(with out: MessageQueue) async throws {
         //~/Library/Android/sdk/emulator/emulator -list-avds
 
+        #if canImport(SkipDriveExternal)
         var exitCode: SkipDriveExternal.ProcessResult.ExitStatus? = nil
         let output = try await launchTool("emulator", arguments: ["-list-avds"]) {
             exitCode = $0.exitStatus
@@ -1272,6 +1273,9 @@ struct AndroidEmulatorListCommand: MessageCommand, ToolOptionsCommand {
         guard let exitCode = exitCode, case .terminated(0) = exitCode else {
             throw EmulatorListError(errorDescription: "Error listing active emulators: \(String(describing: exitCode))")
         }
+        #else
+        throw EmulatorListError(errorDescription: "Error listing active emulators: SkipDriveExternal not available")
+        #endif
     }
 
     public struct EmulatorListError : LocalizedError {

--- a/Sources/SkipSyntax/Bridging.swift
+++ b/Sources/SkipSyntax/Bridging.swift
@@ -11,14 +11,17 @@ public enum AutoBridge: Int {
 }
 
 /// Whether a declaration is briging.
-func isBridging(attributes: Attributes, visibility: Modifiers.Visibility, autoBridge: AutoBridge) -> Bool {
+func isBridging(attributes: Attributes, visibility: Modifiers.Visibility, bridgeMemberVisibility: Modifiers.Visibility?, autoBridge: AutoBridge) -> Bool {
     guard !attributes.isBridge else {
         return true
     }
-    guard autoBridge != .none && autoBridge != .default else {
+    guard !attributes.isNoBridge && !attributes.contains(.unavailable) else {
         return false
     }
-    guard !attributes.isNoBridge && !attributes.contains(.unavailable) else {
+    if let bridgeMemberVisibility, visibility >= .public || visibility >= bridgeMemberVisibility {
+        return true
+    }
+    guard autoBridge != .none && autoBridge != .default else {
         return false
     }
     return visibility >= .public || (autoBridge == .internal && visibility > .fileprivate)

--- a/Sources/SkipSyntax/Decoding.swift
+++ b/Sources/SkipSyntax/Decoding.swift
@@ -55,6 +55,8 @@ struct DecodeContext {
 struct DecodeFlags: OptionSet {
     /// Decoding for SwiftUI state only
     static let swiftUIState = DecodeFlags(rawValue: 1 << 0)
+    /// Bridge members
+    static let bridgeMembers = DecodeFlags(rawValue: 1 << 1)
 
     let rawValue: Int
 

--- a/Sources/SkipSyntax/HelperTypes.swift
+++ b/Sources/SkipSyntax/HelperTypes.swift
@@ -224,7 +224,12 @@ struct Attributes: Hashable, PrettyPrintable, Codable {
 
     /// Convenience to check whether this member is marked to bridge.
     var isBridge: Bool {
-        return contains(directive: "bridge") || contains(.bridge)
+        return contains(directive: "bridge") || contains(directive: "bridgeMembers") || contains(.bridge)
+    }
+
+    /// Convenience to check whether this member is marked to bridge.
+    var isBridgeMembers: Bool {
+        return contains(directive: "bridgeMembers")
     }
 
     /// Convenience to check whether this member is marked to ignore bridging.

--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeToSwiftVisitor.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeToSwiftVisitor.swift
@@ -30,7 +30,7 @@ final class KotlinBridgeToSwiftVisitor {
         syntaxTree.root.visit(ifSkipBlockContent: isBridgeFile) { node in
             if let variableDeclaration = node as? KotlinVariableDeclaration {
                 let variableIsBridging = {
-                    return isBridging(attributes: variableDeclaration.attributes, visibility: variableDeclaration.modifiers.visibility, autoBridge: isBridgeFile ? .internal : self.syntaxTree.autoBridge)
+                    return isBridging(attributes: variableDeclaration.attributes, visibility: variableDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isBridgeFile ? .internal : self.syntaxTree.autoBridge)
                 }
                 if variableDeclaration.role == .global || variableDeclaration.extends != nil, variableIsBridging() {
                     if variableDeclaration.extends != nil && variableDeclaration.isStatic {
@@ -43,7 +43,7 @@ final class KotlinBridgeToSwiftVisitor {
                 return .skip
             } else if let functionDeclaration = node as? KotlinFunctionDeclaration {
                 let functionIsBridging = {
-                    return isBridging(attributes: functionDeclaration.attributes, visibility: functionDeclaration.modifiers.visibility, autoBridge: isBridgeFile ? .internal : self.syntaxTree.autoBridge)
+                    return isBridging(attributes: functionDeclaration.attributes, visibility: functionDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isBridgeFile ? .internal : self.syntaxTree.autoBridge)
                 }
                 if functionDeclaration.role == .global || functionDeclaration.extends != nil, functionIsBridging() {
                     if functionDeclaration.extends != nil && functionDeclaration.isStatic {
@@ -59,19 +59,19 @@ final class KotlinBridgeToSwiftVisitor {
                 return .skip
             } else if let classDeclaration = node as? KotlinClassDeclaration {
                 hasContentComposer = hasContentComposer || (syntaxTree.isBridgeFile && updateContentComposer(classDeclaration))
-                if isBridging(attributes: classDeclaration.attributes, visibility: classDeclaration.modifiers.visibility, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
+                if isBridging(attributes: classDeclaration.attributes, visibility: classDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
                     update(classDeclaration, swiftDefinitions: &swiftDefinitions)
                     checkIfNotSkipBridge(classDeclaration)
                 }
                 return .recurse(nil)
             } else if let interfaceDeclaration = node as? KotlinInterfaceDeclaration {
-                if isBridging(attributes: interfaceDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
+                if isBridging(attributes: interfaceDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
                     update(interfaceDeclaration, swiftDefinitions: &swiftDefinitions)
                     checkIfNotSkipBridge(interfaceDeclaration)
                 }
                 return .recurse(nil)
             } else if let typealiasDeclaration = node as? KotlinTypealiasDeclaration {
-                if isBridging(attributes: typealiasDeclaration.attributes, visibility:  typealiasDeclaration.modifiers.visibility, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
+                if isBridging(attributes: typealiasDeclaration.attributes, visibility: typealiasDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isBridgeFile ? .internal : syntaxTree.autoBridge) {
                     update(typealiasDeclaration, swiftDefinitions: &swiftDefinitions)
                     checkIfNotSkipBridge(typealiasDeclaration)
                 }
@@ -954,6 +954,7 @@ final class KotlinBridgeToSwiftVisitor {
         var hasHashDefinition = false
         var functionCount = 0
         var enumCases: [KotlinEnumCaseDeclaration] = []
+        let bridgeMemberVisibility = classDeclaration.attributes.isBridgeMembers ? classDeclaration.modifiers.visibility : nil
         for member in classDeclaration.members {
             if let enumCaseDeclaration = member as? KotlinEnumCaseDeclaration {
                 if update(member: enumCaseDeclaration, swiftDefinitions: &memberDefinitions) {
@@ -967,7 +968,7 @@ final class KotlinBridgeToSwiftVisitor {
                     // We add our own View contract implementation
                     continue
                 }
-                guard isBridging(attributes: variableDeclaration.attributes, visibility: variableDeclaration.modifiers.visibility, autoBridge: syntaxTree.isBridgeFile ? .internal : syntaxTree.autoBridge) else {
+                guard isBridging(attributes: variableDeclaration.attributes, visibility: variableDeclaration.modifiers.visibility, bridgeMemberVisibility: bridgeMemberVisibility, autoBridge: syntaxTree.isBridgeFile ? .internal : syntaxTree.autoBridge) else {
                     continue
                 }
                 let info = typeInfos.flatMap({ $0.variables }).first(where: { $0.name == (variableDeclaration.preEscapedPropertyName ?? variableDeclaration.propertyName) && $0.modifiers.visibility >= .fileprivate })
@@ -980,7 +981,7 @@ final class KotlinBridgeToSwiftVisitor {
                 guard !functionDeclaration.isGenerated || functionDeclaration.type == .constructorDeclaration else {
                     continue
                 }
-                guard isBridging(attributes: functionDeclaration.attributes, visibility: functionDeclaration.modifiers.visibility, autoBridge: syntaxTree.isBridgeFile ? .internal : syntaxTree.autoBridge) else {
+                guard isBridging(attributes: functionDeclaration.attributes, visibility: functionDeclaration.modifiers.visibility, bridgeMemberVisibility: bridgeMemberVisibility, autoBridge: syntaxTree.isBridgeFile ? .internal : syntaxTree.autoBridge) else {
                     continue
                 }
                 // Don't attempt to bridge @Composable functions
@@ -1433,15 +1434,16 @@ final class KotlinBridgeToSwiftVisitor {
 
         var memberDefinitions: [SwiftDefinition] = []
         var functionCount = 0
+        let bridgeMemberVisibility = interfaceDeclaration.attributes.isBridgeMembers ? interfaceDeclaration.modifiers.visibility : nil
         for member in interfaceDeclaration.members {
             if let variableDeclaration = member as? KotlinVariableDeclaration {
-                guard isBridging(attributes: variableDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, autoBridge: syntaxTree.autoBridge) else {
+                guard isBridging(attributes: variableDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, bridgeMemberVisibility: bridgeMemberVisibility, autoBridge: syntaxTree.autoBridge) else {
                     continue
                 }
                 let info = primaryTypeInfo.variables.first { $0.name == (variableDeclaration.preEscapedPropertyName ?? variableDeclaration.propertyName) }
                 update(member: variableDeclaration, info: info, in: interfaceDeclaration, swiftDefinitions: &memberDefinitions)
             } else if let functionDeclaration = member as? KotlinFunctionDeclaration {
-                guard isBridging(attributes: functionDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, autoBridge: syntaxTree.autoBridge) else {
+                guard isBridging(attributes: functionDeclaration.attributes, visibility: interfaceDeclaration.modifiers.visibility, bridgeMemberVisibility: bridgeMemberVisibility, autoBridge: syntaxTree.autoBridge) else {
                     continue
                 }
                 let info = primaryTypeInfo.functions.first(where: { $0.name == (functionDeclaration.preEscapedName ?? functionDeclaration.name) && $0.signature == functionDeclaration.functionType && $0.modifiers.visibility >= .fileprivate })
@@ -1496,7 +1498,7 @@ final class KotlinBridgeToSwiftVisitor {
             } else if protocolSignature.isComparable {
                 swift.append(1, self.swift(forLessThanDeclarationIn: bridgeImpl, options: options, modifiers: Modifiers(visibility: protocolVisibility, isStatic: true)))
             } else if let protocolInfo = codebaseInfo.primaryTypeInfo(forNamed: protocolSignature) {
-                guard isBridging(attributes: protocolInfo.attributes, visibility: protocolInfo.modifiers.visibility, autoBridge: autoBridge) else {
+                guard isBridging(attributes: protocolInfo.attributes, visibility: protocolInfo.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: autoBridge) else {
                     continue
                 }
                 swift.append(1, self.swift(forProtocolBridgeImplMembers: protocolInfo, visibility: protocolVisibility, options: options, codebaseInfo: codebaseInfo, autoBridge: autoBridge, functionCount: &functionCount))
@@ -1523,7 +1525,8 @@ final class KotlinBridgeToSwiftVisitor {
     }
 
     private static func swift(forProtocolBridgeImplVariable variableInfo: CodebaseInfo.VariableInfo, in info: CodebaseInfo.TypeInfo, visibility: Modifiers.Visibility, options: KotlinBridgeOptions, codebaseInfo: CodebaseInfo.Context, autoBridge: AutoBridge) -> [String] {
-        guard isBridging(attributes: variableInfo.attributes, visibility: visibility, autoBridge: autoBridge) else {
+        let bridgeMembersVisibility = info.attributes.isBridgeMembers ? info.modifiers.visibility : nil
+        guard isBridging(attributes: variableInfo.attributes, visibility: visibility, bridgeMemberVisibility: bridgeMembersVisibility, autoBridge: autoBridge) else {
             return []
         }
         guard let bridgable = variableInfo.signature.checkBridgable(direction: .any, options: options, generics: info.generics, codebaseInfo: codebaseInfo) else {
@@ -1536,7 +1539,8 @@ final class KotlinBridgeToSwiftVisitor {
     }
 
     private static func swift(forProtocolBridgeImplFunction functionInfo: CodebaseInfo.FunctionInfo, in info: CodebaseInfo.TypeInfo, visibility: Modifiers.Visibility, options: KotlinBridgeOptions, codebaseInfo: CodebaseInfo.Context, autoBridge: AutoBridge, uniquifier: Int) -> [String] {
-        guard isBridging(attributes: functionInfo.attributes, visibility: visibility, autoBridge: autoBridge) else {
+        let bridgeMembersVisibility = info.attributes.isBridgeMembers ? info.modifiers.visibility : nil
+        guard isBridging(attributes: functionInfo.attributes, visibility: visibility, bridgeMemberVisibility: bridgeMembersVisibility, autoBridge: autoBridge) else {
             return []
         }
         guard let bridgable = functionInfo.signature.checkFunctionBridgable(direction: .any, isConstructor: functionInfo.declarationType == .initDeclaration, options: options, generics: info.generics.merge(overrides: functionInfo.generics, addNew: true), codebaseInfo: codebaseInfo) else {
@@ -1590,7 +1594,8 @@ final class KotlinBridgeToSwiftVisitor {
     }
 
     private static func swift(forProtocolExtensionVariable variableInfo: CodebaseInfo.VariableInfo, in info: CodebaseInfo.TypeInfo, visibility: Modifiers.Visibility, options: KotlinBridgeOptions, codebaseInfo: CodebaseInfo.Context, autoBridge: AutoBridge) -> [String] {
-        guard isBridging(attributes: variableInfo.attributes, visibility: visibility, autoBridge: autoBridge) else {
+        let bridgeMembersVisibility = info.attributes.isBridgeMembers ? info.modifiers.visibility : nil
+        guard isBridging(attributes: variableInfo.attributes, visibility: visibility, bridgeMemberVisibility: bridgeMembersVisibility, autoBridge: autoBridge) else {
             return []
         }
         guard let bridgable = variableInfo.signature.checkBridgable(direction: .any, options: options, generics: info.generics, codebaseInfo: codebaseInfo) else {
@@ -1602,7 +1607,8 @@ final class KotlinBridgeToSwiftVisitor {
     }
 
     private static func swift(forProtocolExtensionFunction functionInfo: CodebaseInfo.FunctionInfo, in info: CodebaseInfo.TypeInfo, visibility: Modifiers.Visibility, options: KotlinBridgeOptions, codebaseInfo: CodebaseInfo.Context, autoBridge: AutoBridge, uniquifier: Int) -> [String] {
-        guard isBridging(attributes: functionInfo.attributes, visibility: visibility, autoBridge: autoBridge) else {
+        let bridgeMembersVisibility = info.attributes.isBridgeMembers ? info.modifiers.visibility : nil
+        guard isBridging(attributes: functionInfo.attributes, visibility: visibility, bridgeMemberVisibility: bridgeMembersVisibility, autoBridge: autoBridge) else {
             return []
         }
         guard let bridgable = functionInfo.signature.checkFunctionBridgable(direction: .any, isConstructor: functionInfo.declarationType == .initDeclaration, options: options, generics: info.generics.merge(overrides: functionInfo.generics, addNew: true), codebaseInfo: codebaseInfo) else {

--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -47,7 +47,7 @@ public final class KotlinBridgeTransformer: KotlinTransformer {
         syntaxTree.root.visit { node in
             if let typeDeclaration = node as? TypeDeclaration, typeDeclaration.type != .extensionDeclaration {
                 let isNativeIfSkipBlock = isBridgeFile && typeDeclaration.isInIfSkipBlock()
-                if isBridging(attributes: typeDeclaration.attributes, visibility: typeDeclaration.modifiers.visibility, autoBridge: isNativeIfSkipBlock ? .internal : syntaxTree.autoBridge) {
+                if isBridging(attributes: typeDeclaration.attributes, visibility: typeDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isNativeIfSkipBlock ? .internal : syntaxTree.autoBridge) {
                     if isBridgeFile && !isNativeIfSkipBlock {
                         typeDeclaration.attributes.attributes.append(.bridgeToKotlin)
                     } else {
@@ -57,7 +57,7 @@ public final class KotlinBridgeTransformer: KotlinTransformer {
                 return .recurse(nil)
             } else if let typealiasDeclaration = node as? TypealiasDeclaration {
                 let isNativeIfSkipBlock = isBridgeFile && typealiasDeclaration.isInIfSkipBlock()
-                if isBridging(attributes: typealiasDeclaration.attributes, visibility: typealiasDeclaration.modifiers.visibility, autoBridge: isNativeIfSkipBlock ? .internal : syntaxTree.autoBridge) {
+                if isBridging(attributes: typealiasDeclaration.attributes, visibility: typealiasDeclaration.modifiers.visibility, bridgeMemberVisibility: nil, autoBridge: isNativeIfSkipBlock ? .internal : syntaxTree.autoBridge) {
                     if isBridgeFile && !isNativeIfSkipBlock {
                         typealiasDeclaration.attributes.attributes.append(.bridgeToKotlin)
                     } else {

--- a/Sources/SkipSyntax/Statement.swift
+++ b/Sources/SkipSyntax/Statement.swift
@@ -48,7 +48,13 @@ class Statement: SyntaxNode {
         } else {
             effectiveVisibility = visibility
         }
-        return isBridging(attributes: attributes, visibility: effectiveVisibility, autoBridge: syntaxTree.autoBridge) ? .api : .none
+        let bridgeMemberVisibility: Modifiers.Visibility?
+        if let memberOf = context.memberOf, memberOf.flags.contains(.bridgeMembers) {
+            bridgeMemberVisibility = memberOf.modifiers.visibility
+        } else {
+            bridgeMemberVisibility = nil
+        }
+        return isBridging(attributes: attributes, visibility: effectiveVisibility, bridgeMemberVisibility: bridgeMemberVisibility, autoBridge: syntaxTree.autoBridge) ? .api : .none
     }
 }
 

--- a/Sources/SkipSyntax/StatementTypes.swift
+++ b/Sources/SkipSyntax/StatementTypes.swift
@@ -1008,7 +1008,8 @@ final class ExtensionDeclaration: TypeDeclaration {
             return []
         }
         var context = context
-        context.memberOf = (.extensionDeclaration, modifiers, [])
+        let decodeFlags: DecodeFlags = attributes.isBridgeMembers ? [.bridgeMembers] : []
+        context.memberOf = (.extensionDeclaration, modifiers, decodeFlags)
 
         let (inherits, inheritsMessages) = extensionDecl.inheritanceClause?.inheritedTypes.typeSignatures(in: syntaxTree) ?? ([], [])
         let (generics, genericsMessages) = Generics.for(syntax: nil, where: extensionDecl.genericWhereClause, in: syntaxTree)
@@ -1533,7 +1534,8 @@ class TypeDeclaration: Statement {
             return nil
         }
         var context = context
-        context.memberOf = (.classDeclaration, modifiers, [])
+        let decodeFlags: DecodeFlags = attributes.isBridgeMembers ? [.bridgeMembers] : []
+        context.memberOf = (.classDeclaration, modifiers, decodeFlags)
 
         let (inherits, inheritsMessages) = classDecl.inheritanceClause?.inheritedTypes.typeSignatures(in: syntaxTree) ?? ([], [])
         let (generics, genericsMessages) = Generics.for(syntax: classDecl.genericParameterClause, where: classDecl.genericWhereClause, in: syntaxTree)
@@ -1561,6 +1563,9 @@ class TypeDeclaration: Statement {
                 return nil
             }
         }
+        if attributes.isBridgeMembers {
+            decodeFlags.insert(.bridgeMembers)
+        }
         var context = context
         context.memberOf = (.structDeclaration, modifiers, decodeFlags)
 
@@ -1580,7 +1585,8 @@ class TypeDeclaration: Statement {
             return nil
         }
         var context = context
-        context.memberOf = (.protocolDeclaration, modifiers, [])
+        let decodeFlags: DecodeFlags = attributes.isBridgeMembers ? [.bridgeMembers] : []
+        context.memberOf = (.protocolDeclaration, modifiers, decodeFlags)
 
         let name = protocolDecl.name.text.removingBacktickEscaping
         let (inherits, inheritsMessages) = protocolDecl.inheritanceClause?.inheritedTypes.typeSignatures(in: syntaxTree) ?? ([], [])
@@ -1611,6 +1617,9 @@ class TypeDeclaration: Statement {
                 return nil
             }
         }
+        if attributes.isBridgeMembers {
+            decodeFlags.insert(.bridgeMembers)
+        }
         var context = context
         context.memberOf = (.enumDeclaration, modifiers, decodeFlags)
 
@@ -1630,7 +1639,8 @@ class TypeDeclaration: Statement {
             return nil
         }
         var context = context
-        context.memberOf = (.actorDeclaration, modifiers, [])
+        let decodeFlags: DecodeFlags = attributes.isBridgeMembers ? [.bridgeMembers] : []
+        context.memberOf = (.actorDeclaration, modifiers, decodeFlags)
 
         let name = actorDecl.name.text.removingBacktickEscaping
         let (inherits, inheritsMessages) = actorDecl.inheritanceClause?.inheritedTypes.typeSignatures(in: syntaxTree) ?? ([], [])

--- a/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
@@ -1327,8 +1327,7 @@ final class BridgeToKotlinTests: XCTestCase {
         """, transformers: transformers)
     }
 
-    // https://github.com/skiptools/skip/issues/519
-    func TODOtestMainActorClosureFunction() async throws {
+    func testMainActorClosureFunction() async throws {
         try await check(swiftBridge: """
         public func f(c: @MainActor (Int) -> Void) -> Int? {
             return nil
@@ -9019,7 +9018,7 @@ final class BridgeToKotlinTests: XCTestCase {
         """, transformers: transformers)
     }
 
-    public func testBundleModule() async throws {
+    func testBundleModule() async throws {
         KotlinBundleTransformer.testSkipAndroidBridge = true
         defer { KotlinBundleTransformer.testSkipAndroidBridge = false }
 
@@ -9059,6 +9058,305 @@ final class BridgeToKotlinTests: XCTestCase {
         }
 
         let NSLocalizedString = AndroidLocalizedString()
+        """, transformers: transformers)
+    }
+
+    func testBridgeNonPublic() async throws {
+        try await check(swiftBridge: """
+        // SKIP @bridge
+        var s = ""
+        """, kotlin: """
+        internal var s: String
+            get() = Swift_s()
+            set(newValue) {
+                Swift_s_set(newValue)
+            }
+        private external fun Swift_s(): String
+        private external fun Swift_s_set(value: String)
+        """, swiftBridgeSupport: """
+        @_cdecl("Java_BridgeKt_Swift_1s")
+        public func BridgeKt_Swift_s(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> JavaString {
+            return s.toJavaObject(options: [])!
+        }
+        @_cdecl("Java_BridgeKt_Swift_1s_1set")
+        public func BridgeKt_Swift_s_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ value: JavaString) {
+            s = String.fromJavaObject(value, options: [])
+        }
+        """, transformers: transformers)
+
+        try await check(swiftBridge: """
+        // SKIP @bridge
+        func f() { }
+        """, kotlin: """
+        internal fun f(): Unit = Swift_f_0()
+        private external fun Swift_f_0()
+        """, swiftBridgeSupport: """
+        @_cdecl("Java_BridgeKt_Swift_1f_10")
+        public func BridgeKt_Swift_f_0(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) {
+            f()
+        }
+        """, transformers: transformers)
+
+        try await check(swiftBridge: """
+        // SKIP @bridge
+        final class C {
+            // SKIP @bridge
+            var i = 0
+        }
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
+
+    func testBridgeMembers() async throws {
+        try await check(swiftBridge: """
+        // SKIP @bridgeMembers
+        final class C {
+            var i = 0
+            private var x = 1
+        }
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
+
+    func testExtensionBridgeMembers() async throws {
+        try await check(swiftBridge: """
+        // SKIP @bridge
+        final class C {
+            var s = ""
+        }
+        // SKIP @bridgeMembers
+        extension C {
+            var i = 1
+        }
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal open var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
         """, transformers: transformers)
     }
 }

--- a/Tests/SkipSyntaxTests/BridgeToSwiftTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToSwiftTests.swift
@@ -5639,4 +5639,313 @@ final class BridgeToSwiftTests: XCTestCase {
         private let Java_myModifierFunc_0_methodID = Java_SourceKt.getStaticMethodID(name: "myModifierFunc", sig: "(Lskip/ui/View;I)Lskip/ui/View;")!
         """, transformers: transformers)
     }
+
+    func testBridgeNonPublic() async throws {
+        try await check(swiftBridge: """
+        #if !SKIP_BRIDGE
+        // SKIP @bridge
+        var s = ""
+        #endif
+        """, kotlin: """
+        internal var s: String
+            get() = Swift_s()
+            set(newValue) {
+                Swift_s_set(newValue)
+            }
+        private external fun Swift_s(): String
+        private external fun Swift_s_set(value: String)
+        """, swiftBridgeSupport: """
+        @_cdecl("Java_BridgeKt_Swift_1s")
+        public func BridgeKt_Swift_s(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> JavaString {
+            return s.toJavaObject(options: [])!
+        }
+        @_cdecl("Java_BridgeKt_Swift_1s_1set")
+        public func BridgeKt_Swift_s_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ value: JavaString) {
+            s = String.fromJavaObject(value, options: [])
+        }
+        """, transformers: transformers)
+
+        try await check(swiftBridge: """
+        #if !SKIP_BRIDGE
+        // SKIP @bridge
+        func f() { }
+        #endif
+        """, kotlin: """
+        internal fun f(): Unit = Swift_f_0()
+        private external fun Swift_f_0()
+        """, swiftBridgeSupport: """
+        @_cdecl("Java_BridgeKt_Swift_1f_10")
+        public func BridgeKt_Swift_f_0(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) {
+            f()
+        }
+        """, transformers: transformers)
+
+        try await check(swiftBridge: """
+        #if !SKIP_BRIDGE
+        // SKIP @bridge
+        final class C {
+            // SKIP @bridge
+            var i = 0
+        }
+        #endif
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
+
+    func testBridgeMembers() async throws {
+        try await check(swiftBridge: """
+        #if !SKIP_BRIDGE
+        // SKIP @bridgeMembers
+        final class C {
+            var i = 0
+            private var x = 1
+        }
+        #endif
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
+
+    func testExtensionBridgeMembers() async throws {
+        try await check(swiftBridge: """
+        #if !SKIP_BRIDGE
+        // SKIP @bridge
+        final class C {
+            var s = ""
+        }
+        // SKIP @bridgeMembers
+        extension C {
+            var i = 1
+        }
+        #endif
+        """, kotlin: """
+        internal class C: skip.bridge.SwiftPeerBridged, skip.lib.SwiftProjecting {
+            var Swift_peer: skip.bridge.SwiftObjectPointer = skip.bridge.SwiftObjectNil
+
+            constructor(Swift_peer: skip.bridge.SwiftObjectPointer, marker: skip.bridge.SwiftPeerMarker?) {
+                this.Swift_peer = Swift_peer
+            }
+
+            fun finalize() {
+                Swift_release(Swift_peer)
+                Swift_peer = skip.bridge.SwiftObjectNil
+            }
+            private external fun Swift_release(Swift_peer: skip.bridge.SwiftObjectPointer)
+
+            constructor() {
+                Swift_peer = Swift_constructor()
+            }
+            private external fun Swift_constructor(): skip.bridge.SwiftObjectPointer
+
+            override fun Swift_peer(): skip.bridge.SwiftObjectPointer = Swift_peer
+
+            override fun equals(other: Any?): Boolean {
+                if (other !is skip.bridge.SwiftPeerBridged) return false
+                return Swift_peer == other.Swift_peer()
+            }
+
+            override fun hashCode(): Int = Swift_peer.hashCode()
+
+            internal open var i: Int
+                get() = Swift_i(Swift_peer)
+                set(newValue) {
+                    Swift_i_set(Swift_peer, newValue)
+                }
+            private external fun Swift_i(Swift_peer: skip.bridge.SwiftObjectPointer): Int
+            private external fun Swift_i_set(Swift_peer: skip.bridge.SwiftObjectPointer, value: Int)
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+        }
+        """, swiftBridgeSupport: """
+        extension C: BridgedToKotlin, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "C")
+            nonisolated static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                let ptr = SwiftObjectPointer.peer(of: obj!, options: options)
+                return ptr.pointee()!
+            }
+            nonisolated func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                let Swift_peer = SwiftObjectPointer.pointer(to: self, retain: true)
+                return try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: options, args: [Swift_peer.toJavaParameter(options: options), (nil as JavaObjectPointer?).toJavaParameter(options: options)])
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "(JLskip/bridge/SwiftPeerMarker;)V")!
+        }
+        @_cdecl("Java_C_Swift_1constructor")
+        public func C_Swift_constructor(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> SwiftObjectPointer {
+            let f_return_swift = C()
+            return SwiftObjectPointer.pointer(to: f_return_swift, retain: true)
+        }
+        @_cdecl("Java_C_Swift_1release")
+        public func C_Swift_release(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) {
+            Swift_peer.release(as: C.self)
+        }
+        @_cdecl("Java_C_Swift_1i")
+        public func C_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer) -> Int32 {
+            let peer_swift: C = Swift_peer.pointee()!
+            return Int32(peer_swift.i)
+        }
+        @_cdecl("Java_C_Swift_1i_1set")
+        public func C_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ Swift_peer: SwiftObjectPointer, _ value: Int32) {
+            let peer_swift: C = Swift_peer.pointee()!
+            peer_swift.i = Int(value)
+        }
+        @_cdecl("Java_C_Swift_1projectionImpl")
+        public func C_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = C.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
 }


### PR DESCRIPTION
This bridges the target type and all members of at least the same visibility that are not marked @nobridge.