### PR TITLE
Mark debug builds in `skip --help` and `skip doctor`

### DIFF
--- a/Sources/SkipBuild/Commands/DoctorCommand.swift
+++ b/Sources/SkipBuild/Commands/DoctorCommand.swift
@@ -120,7 +120,21 @@ extension ToolOptionsCommand where Self : StreamingCommand {
 
         //await checkVersion(title: "ECHO2 VERSION", cmd: ["sh", "-c", "echo ONE ; sleep 1; echo TWO ; sleep 1; echo THREE ; sleep 1; echo 3.2.1"], min: Version("1.2.3"), pattern: "([0-9.]+)", watch: true)
 
-        try await checkVersion(title: "Skip version", cmd: [skipcmd, "version"], min: Version(skipVersion), pattern: "Skip version ([0-9.]+)")
+        // Skip version: special-case debug builds to show .warn (yellow !) instead of .pass
+        if isDebug {
+            try await run(with: out, "Skip version", [skipcmd, "version"], watch: false, resultHandler: { result in
+                guard let skipVersion = try? result?.get().stdout.trimmingCharacters(in: .newlines) else {
+                    return (result, MessageBlock(status: .fail, "Skip version: error executing \(skipcmd)"))
+                }
+                if skipVersion.contains("debug") {
+                    return (result, MessageBlock(status: .warn, skipVersion))
+                } else {
+                    return (result, MessageBlock(status: .pass, "Skip version \(skipVersion) [debug]"))
+                }
+            })
+        } else {
+            try await checkVersion(title: "Skip version", cmd: [skipcmd, "version"], min: Version(skipVersion), pattern: "Skip version ([0-9.]+)")
+        }
         #if os(macOS)
         try await checkVersion(title: "macOS version", cmd: ["sw_vers", "--productVersion"], min: Version("13.5.0"), pattern: "([0-9.]+)")
         #endif

--- a/Sources/SkipBuild/SkipCommand.swift
+++ b/Sources/SkipBuild/SkipCommand.swift
@@ -14,6 +14,12 @@ import struct Universal.JSON
 /// The version of Skip, via `SkipSyntax`
 public let skipVersion = SkipSyntax.skipVersion // we don't want to have to import SkipSyntax just to get the version, so re-export it
 
+#if DEBUG
+public let isDebug = true
+#else
+public let isDebug = false
+#endif
+
 struct Options {
     var preprocessorSymbols: [String] = []
 }
@@ -62,7 +68,7 @@ public func skipstone(_ args: [String]) async throws -> (out: String, err: Strin
 public struct SkipRunnerExecutor: SkipCommandExecutor {
     public static var configuration = CommandConfiguration(
         commandName: "skip",
-        abstract: "skip \(skipVersion)",
+        abstract: "skip \(skipVersion)\(isDebug ? " (debug)" : "")",
         //version: skipVersion,
         shouldDisplay: true,
         subcommands: [


### PR DESCRIPTION
Before, when running my own hand-built Skip:

```
% ./skip --help | grep OVERVIEW
OVERVIEW: skip 1.7.0
% PATH=.:$PATH ./skip doctor | grep "Skip version"
[✓] Skip version 1.7.0 (= 1.7.0)
```

```
% ./skip --help | grep OVERVIEW
OVERVIEW: skip 1.7.0 (debug)
% PATH=.:$PATH ./skip doctor | grep "Skip version"
[!] Skip version 1.7.0 (debug)
```

(I think there might be a better way to mark official builds with `isOfficial` or something? But this is good for a start.)

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

