### PR TITLE
Support custom Gradle properties in `skip.yml`

### DIFF
--- a/Sources/SkipBuild/Commands/TranspileCommand.swift
+++ b/Sources/SkipBuild/Commands/TranspileCommand.swift
@@ -707,9 +707,37 @@ struct TranspileCommand: TranspilePhase, StreamingCommand {
             }
 
             func generateGradleProperties() throws {
-                // TODO: assemble these from skip.yml settings
                 let gradlePropertiesPath = moduleRootPath.parentDirectory.appending(component: "gradle.properties")
-                let gradePropertiesContents = FrameworkProjectLayout.defaultGradleProperties()
+                
+                let defaultPropertiesString = FrameworkProjectLayout.defaultGradleProperties()
+                var properties: [String: String] = [:]
+                
+                for line in defaultPropertiesString.components(separatedBy: .newlines) {
+                    let trimmed = line.trimmingCharacters(in: .whitespaces)
+                    if trimmed.isEmpty || trimmed.hasPrefix("#") {
+                        continue
+                    }
+                    let parts = trimmed.split(separator: "=", maxSplits: 1)
+                    if parts.count == 2 {
+                        let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
+                        let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
+                        properties[key] = value
+                    }
+                }
+                
+                // Merge with custom properties from skip.yml (custom properties override defaults)
+                if let customProperties = skipConfig.gradleProperties {
+                    for (key, value) in customProperties {
+                        properties[key] = value
+                    }
+                }
+                
+                var gradePropertiesContents = ""
+                for (key, value) in properties.sorted(by: { $0.key < $1.key }) {
+                    gradePropertiesContents += "\(key)=\(value)\n"
+                }
+                gradePropertiesContents += "\n"
+                
                 try writeChanges(tag: "gradle config", to: gradlePropertiesPath, contents: gradePropertiesContents.utf8Data, readOnly: true)
             }
         }

--- a/Sources/SkipBuild/SkipConfig.swift
+++ b/Sources/SkipBuild/SkipConfig.swift
@@ -18,6 +18,9 @@ struct SkipConfig : Codable {
 
     /// The native toolchain info
     var toolchain: SkipToolchain?
+
+    /// Custom gradle.properties key-value pairs
+    var gradleProperties: [String: String]?
 }
 
 struct TranspilationConfig : Codable {


### PR DESCRIPTION
Fixes https://github.com/skiptools/skip/issues/587

I tried it out in https://github.com/dfabulich/skipapp-compose-snapshot-sample and it eliminated the need to explicitly pass `-Pandroid.experimental.enableScreenshotTest=true` whenever you run `gradle`, and it thereby fixed `xcodebuild`.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

