### PR TITLE
Fix test resources in Xcode when running in symlinked directory

### DIFF
--- a/Sources/SkipBuild/Commands/TranspileCommand.swift
+++ b/Sources/SkipBuild/Commands/TranspileCommand.swift
@@ -1035,8 +1035,13 @@ struct TranspileCommand: TranspilePhase, StreamingCommand {
                 .appending(component: "Resources")
 
             for resourceFile in resourceURLs.map(\.path).sorted() {
-                guard let resourceSourceURL = moduleNamePaths.compactMap({ (_, folder) in
-                    resourceFile.hasPrefix(folder) ? URL(fileURLWithPath: resourceFile.dropFirst(folder.count).trimmingCharacters(in: CharacterSet(charactersIn: "/")).description, relativeTo: URL(fileURLWithPath: folder, isDirectory: true)) : nil }).first else {
+                let resourceFileCanonical = (resourceFile as NSString).standardizingPath
+                guard let resourceSourceURL = moduleNamePaths.compactMap({ (_, folder) -> URL? in
+                    let folderCanonical = (folder as NSString).standardizingPath
+                    guard resourceFileCanonical.hasPrefix(folderCanonical) else { return nil }
+                    let relativePath = String(resourceFileCanonical.dropFirst(folderCanonical.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                    return URL(fileURLWithPath: relativePath, relativeTo: URL(fileURLWithPath: folderCanonical, isDirectory: true))
+                }).first else {
                     // skip over resources that are not contained within the Resources/ folder (such as files in the Skip/ folder, which contain metadata that should not be copied)
                     msg(.trace, "no module root parent for \(resourceFile)")
                     continue


### PR DESCRIPTION
Fixes https://github.com/skiptools/skip/issues/622

`/tmp` on macOS is a symlink to `/private/tmp`. We need to canonicalize both paths with `(path as NSString).standardizingPath` before we call `.hasPrefix` on them.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I used Cursor to automatically add logging statements. It found the path mismatch and fixed it, and I reviewed the result (all six lines).

-----

