### PR TITLE
Fix error in JNI cdecl name generation

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -293,6 +293,7 @@ extension String {
     var cdeclEscaped: String {
         self.compactMap { ch -> String in
             switch ch {
+            case ".": return "."
             case "_": return "_1"
             case "/": return "_"
             case ";": return "_2"


### PR DESCRIPTION
Fixes missing "." handing in name generation introduced in https://github.com/skiptools/skipstone/pull/191
