### PR TITLE
Search for emulator in ANDROID_HOME

### DIFF
--- a/Sources/SkipBuild/SkipCommand.swift
+++ b/Sources/SkipBuild/SkipCommand.swift
@@ -1059,16 +1059,21 @@ struct ToolOptions: ParsableArguments {
 
     /// Returns the path to the emulator binary
     var emulatorBinary: String {
+        if let androidHome = ProcessInfo.androidHome {
+            let androidHomeEmulator = "\(androidHome)/emulator/emulator"
+            if FileManager.default.isExecutableFile(atPath: androidHomeEmulator) {
+                return androidHomeEmulator
+            }
+        }
+
         // on Linux for Homebrew: /home/linuxbrew/.linuxbrew/share/android-commandlinetools/emulator/emulator
         // on macOS for Homebrew: /opt/homebrew/share/android-commandlinetools/emulator/emulator
-        // on macOS: ~/Library/Android/sdk/emulator/emulator
-        var emulatorBinary = ProcessInfo.homebrewRoot + "/share/android-commandlinetools/emulator/emulator"
-        // check whether it exists, and if not, fallback to ~/Library/Android/sdk/emulator/emulator or path
-        if !FileManager.default.isExecutableFile(atPath: emulatorBinary) {
-            // TODO: search around for, e.g., Android Studio's version
-            emulatorBinary = "emulator" // fallback to checking PATH
+        let homebrewEmulator = "\(ProcessInfo.homebrewRoot)/share/android-commandlinetools/emulator/emulator"
+        if FileManager.default.isExecutableFile(atPath: homebrewEmulator) {
+            return homebrewEmulator
         }
-        return emulatorBinary
+        // last resort: try to find it in the PATH
+        return "emulator"
     }
 
 }


### PR DESCRIPTION
Fixes #188

In general, I've been nudging Skip to prefer using the tools installed by Android Studio over Homebrew's tools, and this PR is one example of that.

In a UTM environment following my test plan in https://github.com/skiptools/skip/issues/632 where we've only just installed Xcode, Android Studio, and Skip, Homebrew's ANDROID_HOME in `/opt/homebrew/share/android-commandlinetools` only contains one directory, `cmdline-tools`. `cmdline-tools/latest/bin` contains `sdkmanager` and `avdmanager`, but no `emulator/emulator` and no `platform-tools/adb`.

In this PR, we first try to find the emulator in ANDROID_HOME. If you've installed Android Studio and clicked Next Next Next as you ran it, Android Studio will have already installed `emulator/emulator` there.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

