### PR TITLE
Make `skip android emulator create` much more robust

### DIFF
--- a/Sources/SkipBuild/Commands/AndroidCommand.swift
+++ b/Sources/SkipBuild/Commands/AndroidCommand.swift
@@ -1081,6 +1081,9 @@ struct AndroidEmulatorCreateCommand: MessageCommand {
 
     @Option(help: ArgumentHelp("Android emulator architecture", valueName: "arch"))
     var arch: String = Self.defaultArch
+    
+    /// Environment variables for testing (defaults to process environment)
+    var env: [String: String] = ProcessInfo.processInfo.environment
 
     static let defaultArch: String = {
         #if arch(arm64)
@@ -1097,39 +1100,63 @@ struct AndroidEmulatorCreateCommand: MessageCommand {
     }()
 
     func performCommand(with out: MessageQueue) async throws {
+        let javaHome = try await validateJava(command: self, environment: self.env, out: out)
+
+        let androidHome = try await validateAndroidHome(environment: self.env, out: out)
+
+        _ = try await validateCmdlineTools(
+            command: self,
+            androidHome: androidHome,
+            javaHome: javaHome,
+            environment: self.env,
+            out: out
+        )
+
+        let actualAPILevel = self.androidAPILevel
+
+        var defaultName = "emulator-\(actualAPILevel)"
+        defaultName += "-\(deviceProfile.lowercased().replacing(" ", with: "-"))"
+        let emulatorName = name ?? defaultName
+
         func sdkmanagerInstall(_ package: String) async throws {
-            try await run(with: out, "Install \(package)", ["sdkmanager", "--verbose", "--install", package])
+            try await run(with: out, "Install \(package)", ["\(androidHome)/cmdline-tools/latest/bin/sdkmanager", "--verbose", "--install", package], additionalEnvironment: ["JAVA_HOME": javaHome])
         }
 
         await withLogStream(title: "Create Android emulator", with: out) {
-            try await run(with: out, "Configure Android SDK Manager", ["sh", "-c", "yes | sdkmanager --licenses"])
+            let emulatorSpec = self.package ?? "system-images;android-\(androidAPILevel);\(systemImage);\(arch)"
+            let emulatorSpecParts = emulatorSpec.split(separator: ";")
+            let androidPlatform = emulatorSpecParts.dropFirst().first ?? "android-\(androidAPILevel)"
+
+            try await run(with: out, "Configure Android SDK Manager", ["sh", "-c", "yes | \(androidHome)/cmdline-tools/latest/bin/sdkmanager --licenses"], additionalEnvironment: ["JAVA_HOME": javaHome])
 
             try await sdkmanagerInstall("platform-tools")
             try await sdkmanagerInstall("emulator")
 
-            let emulatorSpec = self.package ?? "system-images;android-\(androidAPILevel);\(systemImage);\(arch)"
+            _ = try await findEmulatorPath(androidHome: androidHome, out: out)
 
-            let emulatorSpecParts = emulatorSpec.split(separator: ";")
-            let androidPlatform = emulatorSpecParts.dropFirst().first ?? "android-\(androidAPILevel)"
-            let actualAPILevel = androidPlatform.split(separator: "-").last.flatMap({ Int($0) }) ?? self.androidAPILevel
+            let avdResult = try await checkAVDExists(
+                command: self,
+                androidHome: androidHome,
+                environment: self.env,
+                avdName: emulatorName,
+                out: out
+            )
+
+            if avdResult {
+                await out.write(status: .skip, "AVD '\(emulatorName)' already exists - skipping creation")
+                UserDefaults.standard.set(emulatorName, forKey: lastEmulatorNameDefault)
+                return
+            }
 
             try await sdkmanagerInstall("platforms;\(androidPlatform)")
 
             try await sdkmanagerInstall(emulatorSpec)
 
-            var defaultName = "emulator-\(actualAPILevel)"
-            //if let deviceProfile {
-                defaultName += "-\(deviceProfile.lowercased().replacing(" ", with: "-"))"
-            //}
-            let emulatorName = name ?? defaultName
-
-            var createCommand = ["avdmanager", "create", "avd", "--force", "-n", emulatorName, "--package", emulatorSpec]
-            //if let deviceProfile {
-                createCommand += ["--device", deviceProfile]
-            //}
+            var createCommand = ["\(androidHome)/cmdline-tools/latest/bin/avdmanager", "create", "avd", "--force", "-n", emulatorName, "--package", emulatorSpec]
+            createCommand += ["--device", deviceProfile]
 
             // need to pipe through "no" to decline "Do you wish to create a custom hardware profile? [no]"
-            try await run(with: out, "Create emulator: \(emulatorName)", createCommand)
+            try await run(with: out, "Create emulator: \(emulatorName)", createCommand, additionalEnvironment: ["JAVA_HOME": javaHome])
 
             // save the emulatorName as the default for `skip android emulator launch`
             UserDefaults.standard.set(emulatorName, forKey: lastEmulatorNameDefault)
@@ -1744,4 +1771,358 @@ extension Collection where Element: Hashable {
         }
         return result
     }
+}
+
+// MARK: - Android Emulator Setup Validation
+
+/// Error thrown when Java cannot be found
+struct JavaNotFoundError: LocalizedError {
+    var errorDescription: String? {
+        "Java not found. Install Java 17 or later from https://adoptium.net or run: brew install openjdk"
+    }
+}
+
+/// Validates Java is available using Homebrew openjdk
+/// - Parameters:
+///   - command: The message command to use for executing java -version
+///   - environment: The environment variables to use for finding Java
+///   - out: MessageQueue to yield validation messages
+/// - Returns: The JAVA_HOME path for Homebrew openjdk
+/// - Throws: JavaNotFoundError if Homebrew openjdk cannot be found
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func validateJava(
+    command: some MessageCommand,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    out: MessageQueue
+) async throws -> String {
+    let minimumVersion = "17.0.0"
+
+    // Use Homebrew openjdk
+    // Check the passed environment first (for testing), then fall back to ProcessInfo.homebrewRoot
+    // which itself checks HOMEBREW_PREFIX in the actual process environment
+    let homebrewRoot = environment["HOMEBREW_PREFIX"].flatMap { $0.isEmpty ? nil : $0 }
+        ?? ProcessInfo.homebrewRoot
+    let homebrewJavaHome = "\(homebrewRoot)/opt/openjdk/libexec/openjdk.jdk/Contents/Home"
+    let homebrewJavaPath = "\(homebrewJavaHome)/bin/java"
+
+    // Use the command's run method which generates its own message block with timing
+    guard let result = try? await command.run(
+        with: out,
+        "Check Java version (Homebrew)",
+        [homebrewJavaPath, "-version"],
+        environment: environment
+    ),
+          let output = try? result.get(),
+          let version = extractJavaVersion(output.stderr) ?? extractJavaVersion(output.stdout) else {
+        // Homebrew openjdk not found
+        throw JavaNotFoundError()
+    }
+
+    // Note: The command.run() already generates a message block with timing info
+    // We add an additional success message with the version details
+    await out.write(status: .pass, "Java version \"\(version)\" (> \(minimumVersion))")
+    return homebrewJavaHome
+}
+
+/// Extracts Java version string from java -version output
+/// - Parameter output: The stdout or stderr from java -version
+/// - Returns: The version string (e.g., "25.0.2") or nil if not found
+private func extractJavaVersion(_ output: String) -> String? {
+    // Match patterns like:
+    // openjdk version "25.0.2" 2026-01-20
+    // java version "17.0.8.1" 2023-08-24
+    // java version "1.8.0_392"
+    
+    // Use Swift's modern Regex type (available in Swift 5.7+)
+    let pattern = #"version "([0-9._]+)""#
+    guard let regex = try? Regex(pattern),
+          let match = output.firstMatch(of: regex),
+          let capture = match.output[1].substring else {
+        return nil
+    }
+    
+    let version = String(capture)
+    // Normalize version (e.g., "1.8.0_392" -> "8.0.392")
+    // Handle legacy 1.8 style versions
+    if version.hasPrefix("1.") {
+        // Convert "1.8.0_392" to "8.0.392"
+        let parts = version.dropFirst(2).replacingOccurrences(of: "_", with: ".").split(separator: ".")
+        return parts.joined(separator: ".")
+    }
+    return version
+}
+
+// MARK: - ANDROID_HOME Validation
+
+/// Error thrown when Android SDK cannot be found
+struct AndroidHomeNotFoundError: LocalizedError {
+    let androidHome: String?
+    
+    init(androidHome: String? = nil) {
+        self.androidHome = androidHome
+    }
+    
+    var errorDescription: String? {
+        if let androidHome = androidHome {
+            return "ANDROID_HOME is set to \(androidHome) but the directory does not exist. Install Android Studio from https://developer.android.com/studio or update ANDROID_HOME to your Android SDK path."
+        } else {
+            return "ANDROID_HOME not found. Install Android Studio from https://developer.android.com/studio or set the ANDROID_HOME environment variable to your Android SDK path."
+        }
+    }
+}
+
+/// Validates ANDROID_HOME is set and directory exists
+/// - Parameters:
+///   - environment: The environment variables to check
+///   - out: MessageQueue to yield validation messages
+/// - Returns: The path to the Android SDK
+/// - Throws: AndroidHomeNotFoundError if no Android SDK can be found
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func validateAndroidHome(
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    out: MessageQueue
+) async throws -> String {
+    // Try 1: ANDROID_HOME environment variable
+    if let androidHome = environment["ANDROID_HOME"], !androidHome.isEmpty {
+        if FileManager.default.fileExists(atPath: androidHome) {
+            await out.write(status: .pass, "ANDROID_HOME = \(androidHome)")
+            return androidHome
+        } else {
+            throw AndroidHomeNotFoundError(androidHome: androidHome)
+        }
+    }
+
+    // Try 2: Default platform-specific paths
+    // Use the passed HOME environment variable (for testing), or fall back to actual home directory
+    let home = environment["HOME"].flatMap { $0.isEmpty ? nil : $0 } ?? FileManager.default.homeDirectoryForCurrentUser.path
+
+    #if os(macOS)
+    let defaultPath = "\(home)/Library/Android/sdk"
+    #elseif os(Linux)
+    let defaultPath = "\(home)/Android/Sdk"
+    #elseif os(Windows)
+    let defaultPath = "\(home)/AppData/Local/Android/Sdk"
+    #else
+    throw AndroidHomeNotFoundError()
+    #endif
+
+    if FileManager.default.fileExists(atPath: defaultPath) {
+        await out.write(status: .pass, "ANDROID_HOME = \(defaultPath)")
+        return defaultPath
+    }
+
+    // All fallbacks failed
+    throw AndroidHomeNotFoundError()
+}
+
+// MARK: - cmdline-tools Validation
+
+/// Error thrown when cmdline-tools cannot be found
+struct CmdlineToolsNotFoundError: LocalizedError {
+    var errorDescription: String? {
+        "Android SDK Command-line Tools not found. Install with: brew install android-commandlinetools"
+    }
+}
+
+/// Error thrown when cmdline-tools bootstrap installation fails
+struct CmdlineToolsBootstrapFailedError: LocalizedError {
+    var errorDescription: String? {
+        "Failed to install the Android SDK Command-line Tools in your ANDROID_HOME. This appears to be a bug in Skip. Try using Android Studio to install the Command-line Tools."
+    }
+}
+
+/// Result of cmdline-tools validation
+struct CmdlineToolsResult {
+    let sdkmanagerPath: String
+    let version: String
+    let wasBootstrapped: Bool
+}
+
+/// Validates cmdline-tools are available, "bootstrapping" if necessary
+/// - Parameters:
+///   - command: The message command to use for executing sdkmanager
+///   - androidHome: The ANDROID_HOME path
+///   - javaHome: The JAVA_HOME path (for running sdkmanager)
+///   - environment: The environment variables to use for finding tools
+///   - out: MessageQueue to yield validation messages
+/// - Returns: CmdlineToolsResult containing sdkmanager path and version
+/// - Throws: CmdlineToolsNotFoundError if no sdkmanager can be found
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func validateCmdlineTools(
+    command: some MessageCommand,
+    androidHome: String,
+    javaHome: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    out: MessageQueue
+) async throws -> CmdlineToolsResult {
+    let minimumVersion = "17.0.0"
+    let cmdlineToolsPath = "\(androidHome)/cmdline-tools/latest/bin/sdkmanager"
+
+    // Create environment with JAVA_HOME set
+    var sdkmanagerEnvironment = environment
+    sdkmanagerEnvironment["JAVA_HOME"] = javaHome
+
+    // Check 1: cmdline-tools already installed in ANDROID_HOME
+    if FileManager.default.fileExists(atPath: cmdlineToolsPath) {
+        if let version = try? await getSdkmanagerVersion(command: command, sdkmanagerPath: cmdlineToolsPath, environment: sdkmanagerEnvironment, out: out) {
+            await out.write(status: .pass, "Android command-line tools version \(version) (> \(minimumVersion))")
+            return CmdlineToolsResult(
+                sdkmanagerPath: cmdlineToolsPath,
+                version: version,
+                wasBootstrapped: false
+            )
+        }
+    }
+
+    // At this point, we need to "bootstrap" the cmdline-tools
+    // Our homebrew cask installs `android-commandlinetools` which contains a copy of sdkmanager, but that's probably not the user's ANDROID_HOME
+    // Nevertheless, if we can find any copy of sdkmanager, we can use it to install the cmdline-tools in the user's ANDROID_HOME
+    let homebrewRoot = environment["HOMEBREW_PREFIX"].flatMap { $0.isEmpty ? nil : $0 }
+        ?? ProcessInfo.homebrewRoot
+    let bootstrapPaths = [
+        "\(homebrewRoot)/bin/sdkmanager",
+        "/opt/homebrew/bin/sdkmanager",
+        "/usr/local/bin/sdkmanager",
+        "sdkmanager" // Will search PATH
+    ]
+
+    var bootstrapSdkmanager: String? = nil
+    for path in bootstrapPaths {
+        if FileManager.default.fileExists(atPath: path) || path == "sdkmanager" {
+            // Try to run it to verify it works
+            if (try? await getSdkmanagerVersion(command: command, sdkmanagerPath: path, environment: sdkmanagerEnvironment, out: out)) != nil {
+                bootstrapSdkmanager = path
+                break
+            }
+        }
+    }
+
+    guard let bootstrap = bootstrapSdkmanager else {
+        throw CmdlineToolsNotFoundError()
+    }
+
+    // Bootstrap: install cmdline-tools to ANDROID_HOME
+    // sdkmanager --sdk_root=$ANDROID_HOME "cmdline-tools;latest"
+    // We ignore failures here since we'll verify the installation next
+    await out.write(status: .pass, "Bootstrap sdkmanager = \(bootstrap)")
+    _ = try? await command.run(
+        with: out,
+        "Install cmdline-tools to ANDROID_HOME",
+        [bootstrap, "--sdk_root=\(androidHome)", "cmdline-tools;latest"],
+        environment: sdkmanagerEnvironment
+    )
+
+    // Verify installation succeeded
+    if FileManager.default.fileExists(atPath: cmdlineToolsPath),
+       let version = try? await getSdkmanagerVersion(command: command, sdkmanagerPath: cmdlineToolsPath, environment: sdkmanagerEnvironment, out: out) {
+        await out.write(status: .pass, "Bootstrap sdkmanager = \(bootstrap)")
+        await out.write(status: .pass, "Android command-line tools version \(version) (> \(minimumVersion))")
+        return CmdlineToolsResult(
+            sdkmanagerPath: cmdlineToolsPath,
+            version: version,
+            wasBootstrapped: true
+        )
+    }
+
+    throw CmdlineToolsBootstrapFailedError()
+}
+
+/// Helper to get sdkmanager version
+/// - Throws: Error if the command fails or version cannot be extracted
+private func getSdkmanagerVersion(
+    command: some MessageCommand,
+    sdkmanagerPath: String,
+    environment: [String: String],
+    out: MessageQueue
+) async throws -> String {
+    let result = try await command.run(
+        with: out,
+        "Check sdkmanager version",
+        [sdkmanagerPath, "--version"],
+        environment: environment
+    )
+    let output = try result.get()
+    return output.stdout.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+}
+
+// MARK: - AVD Existence Check
+
+/// Error thrown when emulator command cannot be executed
+struct EmulatorListAVDsError: LocalizedError {
+    let underlyingError: Error
+
+    var errorDescription: String? {
+        "Failed to run emulator -list-avds: \(underlyingError.localizedDescription)"
+    }
+}
+
+/// Checks if an AVD with the given name already exists using `emulator -list-avds`
+/// - Parameters:
+///   - command: The message command to use
+///   - androidHome: The ANDROID_HOME path
+///   - environment: The environment variables
+///   - avdName: The name of the AVD to check for
+///   - out: MessageQueue to yield validation messages
+/// - Returns: `true` if the AVD exists, `false` otherwise
+/// - Throws: EmulatorListAVDsError if emulator command fails
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func checkAVDExists(
+    command: some MessageCommand,
+    androidHome: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment,
+    avdName: String,
+    out: MessageQueue
+) async throws -> Bool {
+    let emulatorPath = "\(androidHome)/emulator/emulator"
+
+    // Run emulator -list-avds for simple name-only output (same output format as avdmanager list avd --compact)
+    let output: ProcessOutput
+    do {
+        let result = try await command.run(
+            with: out,
+            "Check if AVD '\(avdName)' exists",
+            [emulatorPath, "-list-avds"],
+            environment: environment
+        )
+        output = try result.get()
+    } catch {
+        throw EmulatorListAVDsError(underlyingError: error)
+    }
+
+    // Parse the output to find the AVD (just names, one per line)
+    let stdout = output.stdout
+    let avdNames = stdout.split(separator: "\n").map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }.filter { !$0.isEmpty }
+    return avdNames.contains(avdName)
+}
+
+// MARK: - Emulator Path Validation
+
+/// Error thrown when emulator binary cannot be found
+struct EmulatorNotFoundError: LocalizedError {
+    let androidHome: String
+    
+    var errorDescription: String? {
+        "Android Emulator not found at \(androidHome)/emulator/emulator. This appears to be a bug in Skip. Try installing the emulator with: \(androidHome)/cmdline-tools/latest/bin/sdkmanager emulator"
+    }
+}
+
+/// Finds the emulator binary within ANDROID_HOME
+/// - Parameters:
+///   - androidHome: The ANDROID_HOME path
+///   - out: MessageQueue to yield validation messages
+/// - Returns: The path to the emulator binary
+/// - Throws: EmulatorNotFoundError if the emulator binary is not found
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func findEmulatorPath(
+    androidHome: String,
+    out: MessageQueue
+) async throws -> String {
+    let emulatorPath = "\(androidHome)/emulator/emulator"
+
+    guard FileManager.default.fileExists(atPath: emulatorPath) else {
+        throw EmulatorNotFoundError(androidHome: androidHome)
+    }
+
+    await out.write(status: .pass, "Android Emulator: \(emulatorPath)")
+    return emulatorPath
 }

--- a/Tests/SkipBuildTests/AndroidEmulatorSetupTests.swift
+++ b/Tests/SkipBuildTests/AndroidEmulatorSetupTests.swift
@@ -1,0 +1,629 @@
+// Copyright (c) 2023 - 2026 Skip
+// Licensed under the GNU Affero General Public License v3.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import XCTest
+@testable import SkipBuild
+import TSCBasic
+import ArgumentParser
+
+// MARK: - Test Message Command
+
+/// A test command that conforms to MessageCommand for use in validators
+///
+/// Note: To create an instance, use `try TestMessageCommand.parse([])` in your test.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+struct TestMessageCommand: MessageCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "test-message-command",
+        abstract: "Test command for validators",
+        shouldDisplay: false
+    )
+
+    @OptionGroup(title: "Output Options")
+    var outputOptions: OutputOptions
+
+    func performCommand(with out: MessageQueue) async throws {
+        // Test command doesn't do anything by default
+        // It's used as a vehicle to access the run() method for executing sub-commands
+    }
+}
+
+// MARK: - Mock Environment Helpers
+
+/// Helper to create temporary directories with mock scripts for testing
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+struct MockEnvironment {
+    let tempDir: String
+    let homeDir: String
+    let homebrewPrefix: String
+    let androidHome: String
+
+    /// Path to the Homebrew OpenJDK installation (used by validateJava)
+    var javaHome: String {
+        "\(homebrewPrefix)/opt/openjdk/libexec/openjdk.jdk/Contents/Home"
+    }
+
+    /// Path to the emulator binary (ANDROID_HOME/emulator/emulator)
+    var emulatorPath: String {
+        "\(androidHome)/emulator/emulator"
+    }
+
+    init() throws {
+        let baseTemp = "\(FileManager.default.temporaryDirectory.path)/skip-tests-\(UUID().uuidString)"
+
+        self.tempDir = baseTemp
+        self.homeDir = "\(baseTemp)/home"
+        self.homebrewPrefix = "\(baseTemp)/opt/homebrew"
+        self.androidHome = "\(homeDir)/Library/Android/sdk"
+
+        // Create directories
+        try FileManager.default.createDirectory(atPath: tempDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: homeDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(atPath: homebrewPrefix, withIntermediateDirectories: true)
+    }
+    
+    /// Creates a mock executable script at the given path
+    func createMockScript(at path: String, content: String) throws {
+        let parentDir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(atPath: parentDir, withIntermediateDirectories: true)
+        
+        let scriptContent = "#!/bin/bash\n" + content
+        try scriptContent.write(toFile: path, atomically: true, encoding: .utf8)
+        
+        if FileManager.default.fileExists(atPath: path) {
+            _ = chmod(path, 0o755)
+        }
+    }
+    
+    /// Creates a mock executable script that echoes the given string and exits 0
+    func createMockScript(at path: String, echoing: String) throws {
+        try createMockScript(at: path, content: """
+            echo "\(echoing)"
+            exit 0
+            """)
+    }
+    
+    /// Creates a mock java script that outputs the given version to stderr
+    func createMockJava(version: String) throws {
+        try createMockScript(at: "\(javaHome)/bin/java", content: """
+            echo 'openjdk version "\(version)" 2024-01-01' >&2
+            exit 0
+            """)
+    }
+    
+    /// Creates a mock bootstrap sdkmanager at homebrew prefix that installs cmdline-tools to androidHome
+    /// when invoked as: sdkmanager --sdk_root=<androidHome> "cmdline-tools;latest"
+    /// Also creates bootstrap avdmanager and emulator, then copies them to their installed locations
+    func createMockBootstrapSdkmanager() throws {
+        // Create bootstrap avdmanager and emulator that will be copied during installation
+        let bootstrapAvdmanager = "\(homebrewPrefix)/bin/avdmanager"
+        try createMockScript(at: bootstrapAvdmanager, echoing: "Android Virtual Device created successfully")
+
+        let bootstrapEmulator = "\(homebrewPrefix)/share/android-commandlinetools/emulator/emulator"
+        try createMockScript(at: bootstrapEmulator, echoing: "")
+
+        let sdkmanagerPath = "\(homebrewPrefix)/bin/sdkmanager"
+        let cmdlineToolsPath = "\(androidHome)/cmdline-tools/latest/bin"
+        let installedSdkmanager = "\(cmdlineToolsPath)/sdkmanager"
+        let installedAvdmanager = "\(cmdlineToolsPath)/avdmanager"
+        let emulatorPath = "\(androidHome)/emulator/emulator"
+
+        try createMockScript(at: sdkmanagerPath, content: """
+            if [ "$1" = "--version" ]; then
+                echo "20.0"
+            elif [[ "$1" == --sdk_root=* ]] && [ "$2" = "cmdline-tools;latest" ]; then
+                mkdir -p \(cmdlineToolsPath)
+
+                # Create installed sdkmanager that just echoes version
+                echo '#!/bin/bash' > \(installedSdkmanager)
+                echo 'echo "20.0"' >> \(installedSdkmanager)
+                chmod +x \(installedSdkmanager)
+
+                # Copy bootstrap avdmanager to installed location
+                cp \(bootstrapAvdmanager) \(installedAvdmanager)
+
+                # Copy bootstrap emulator to installed location
+                mkdir -p \(androidHome)/emulator
+                cp \(bootstrapEmulator) \(emulatorPath)
+            fi
+            exit 0
+            """)
+    }
+    
+    /// Returns environment variables configured for testing with mock scripts
+    func environment(additional: [String: String] = [:]) -> [String: String] {
+        var env = ProcessInfo.processInfo.environment
+        env["HOME"] = homeDir
+        env["HOMEBREW_PREFIX"] = homebrewPrefix
+        env["ANDROID_HOME"] = androidHome
+        env["PATH"] = "\(homebrewPrefix)/bin:/usr/bin:/bin"
+
+        for (key, value) in additional {
+            env[key] = value
+        }
+
+        return env
+    }
+    
+    /// Cleans up the temporary directory
+    func cleanup() {
+        try? FileManager.default.removeItem(atPath: tempDir)
+    }
+}
+
+// MARK: - XCTest Helpers
+
+extension XCTestCase {
+    /// Asserts that an async expression throws an error
+    func XCTAssertThrowsErrorAsync<T>(
+        _ expression: @escaping () async throws -> T,
+        file: StaticString = #file,
+        line: UInt = #line,
+        _ errorHandler: @escaping (Error) -> Void = { _ in }
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expected error but none was thrown", file: file, line: line)
+        } catch {
+            errorHandler(error)
+        }
+    }
+}
+
+// MARK: - Test Message Queue Helper
+
+/// Helper to run a validator with a collecting queue, returning both the result and the messages
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+func runValidator<T>(
+    _ operation: (MessageQueue) async throws -> T
+) async throws -> (result: T, messages: [MessageBlock]) {
+    let (_, continuation) = MessageStream.makeStream()
+    let queue = MessageQueue(retain: true, continuation: continuation)
+
+    let result = try await operation(queue)
+
+    // Extract message blocks from the queue's elements
+    let elements = await queue.elements
+    let messages: [MessageBlock] = elements.compactMap {
+        switch $0 {
+        case .success(let element as MessageBlock): return element
+        default: return nil
+        }
+    }
+
+    return (result, messages)
+}
+
+// MARK: - AndroidEmulatorSetupTests
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+final class AndroidEmulatorSetupTests: XCTestCase {
+    
+    var mockEnv: MockEnvironment!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        mockEnv = try MockEnvironment()
+    }
+    
+    override func tearDown() async throws {
+        mockEnv?.cleanup()
+        mockEnv = nil
+        try await super.tearDown()
+    }
+    
+    // MARK: - Java Validation Tests
+
+    /// Homebrew openjdk - expect version extracted and javaHome returned
+    func testJavaValidationSucceedsWithHomebrewOpenjdk() async throws {
+        // Create mock java at homebrew location
+        try mockEnv.createMockJava(version: "25.0.2")
+
+        let env = mockEnv.environment()
+        let command = try TestMessageCommand.parse([])
+
+        let (result, messages) = try await runValidator { queue in
+            try await validateJava(command: command, environment: env, out: queue)
+        }
+
+        // validateJava should return the JAVA_HOME path
+        XCTAssertEqual(result, mockEnv.javaHome)
+        // StreamingCommand.run() generates a message block with timing info,
+        // and validateJava adds another message with the version details
+        XCTAssertEqual(messages.count, 2)
+        // First message is from StreamingCommand.run() with timing
+        XCTAssertEqual(messages[0].status, MessageBlock.Status.pass)
+        // Second message is the version message from validateJava
+        XCTAssertEqual(messages[1].status, MessageBlock.Status.pass)
+        XCTAssertTrue(messages[1].message(term: .plain)?.contains("25.0.2") == true)
+    }
+
+    /// No Java available - expect JavaNotFoundError
+    /// This test does not create a mock Java, so the validator will fail to find it
+    func testJavaValidationFailsWhenNoJavaAvailable() async throws {
+        let command = try TestMessageCommand.parse([])
+        let env = mockEnv.environment()
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await validateJava(command: command, environment: env, out: queue)
+            }}
+        ) { error in
+            XCTAssertTrue(error is JavaNotFoundError)
+        }
+    }
+    
+    // MARK: - ANDROID_HOME Validation Tests
+
+    /// Missing ANDROID_HOME and no default - expect AndroidHomeNotFoundError
+    func testAndroidHomeValidationFailsWhenNotSetAndNoDefault() async {
+        // Create a completely isolated environment with no Android SDK
+        let env: [String: String] = [
+            "HOME": mockEnv.homeDir
+        ]
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await validateAndroidHome(environment: env, out: queue)
+            }}
+        ) { error in
+            XCTAssertTrue(error is AndroidHomeNotFoundError, "Expected AndroidHomeNotFoundError but got \(type(of: error))")
+        }
+    }
+
+    /// Environment variable set - expect path
+    func testAndroidHomeValidationSucceedsWithEnvVariable() async throws {
+        let tempDir = mockEnv.tempDir
+
+        let env: [String: String] = [
+            "ANDROID_HOME": mockEnv.tempDir
+        ]
+
+        let (result, messages) = try await runValidator { queue in
+            try await validateAndroidHome(environment: env, out: queue)
+        }
+
+        XCTAssertEqual(result, tempDir)
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.status, MessageBlock.Status.pass)
+    }
+
+    /// Default macOS path using HOME mock
+    #if os(macOS)
+    func testAndroidHomeFallsBackToDefaultMacOSPath() async throws {
+        try FileManager.default.createDirectory(atPath: mockEnv.androidHome, withIntermediateDirectories: true)
+
+        let env: [String: String] = [
+            "HOME": mockEnv.homeDir
+        ]
+
+        let (result, messages) = try await runValidator { queue in
+            try await validateAndroidHome(environment: env, out: queue)
+        }
+
+        XCTAssertEqual(result, mockEnv.androidHome)
+        XCTAssertEqual(messages.count, 1)
+    }
+    #endif
+
+    /// ANDROID_HOME set but points to non-existent directory
+    func testAndroidHomeValidationFailsWhenSetToNonExistentDirectory() async {
+        let env: [String: String] = [
+            "ANDROID_HOME": "/nonexistent/android/sdk",
+            "HOME": mockEnv.tempDir
+        ]
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await validateAndroidHome(environment: env, out: queue)
+            }}
+        ) { error in
+            XCTAssertTrue(error is AndroidHomeNotFoundError)
+            XCTAssertTrue(error.localizedDescription.contains("/nonexistent/android/sdk"))
+        }
+    }
+    
+    // MARK: - cmdline-tools Validation Tests
+
+    /// Missing cmdline-tools with bootstrap available
+    /// The bootstrap sdkmanager script creates the cmdline-tools when executed
+    func testCmdlineToolsBootstrap() async throws {
+        // Create Android SDK without cmdline-tools
+        let androidHome = mockEnv.androidHome
+
+        // Create bootstrap sdkmanager at homebrew location that installs cmdline-tools when run
+        try mockEnv.createMockBootstrapSdkmanager()
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        let (result, messages) = try await runValidator { queue in
+            try await validateCmdlineTools(
+                command: command,
+                androidHome: androidHome,
+                javaHome: mockEnv.javaHome,
+                environment: env,
+                out: queue
+            )
+        }
+
+        XCTAssertTrue(result.wasBootstrapped)
+        XCTAssertEqual(result.sdkmanagerPath, "\(androidHome)/cmdline-tools/latest/bin/sdkmanager")
+        // StreamingCommand.run() generates message blocks with timing info for each command run,
+        // plus validateCmdlineTools writes its own messages
+        // Should have more messages now due to StreamingCommand.run() timing messages
+        XCTAssertGreaterThanOrEqual(messages.count, 2)
+    }
+
+    /// Bootstrap installation fails - cmdline-tools still not present after installation
+    /// The bootstrap script runs but doesn't create cmdline-tools (simulating a failed install)
+    func testCmdlineToolsBootstrapFails() async throws {
+        // Create Android SDK without cmdline-tools
+        let androidHome = mockEnv.androidHome
+
+        // Create bootstrap sdkmanager at homebrew location that does NOT create cmdline-tools
+        // The bootstrap is invoked as: sdkmanager --sdk_root=<androidHome> "cmdline-tools;latest"
+        // (simulating a failed bootstrap installation that doesn't create the files)
+        let bootstrapSdkmanager = "\(mockEnv.homebrewPrefix)/bin/sdkmanager"
+        try? mockEnv.createMockScript(at: bootstrapSdkmanager, echoing: "20.0")
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await validateCmdlineTools(
+                    command: command,
+                    androidHome: androidHome,
+                    javaHome: self.mockEnv.javaHome,
+                    environment: env,
+                    out: queue
+                )
+            }}
+        ) { error in
+            XCTAssertTrue(error is CmdlineToolsBootstrapFailedError)
+        }
+    }
+
+    /// Existing cmdline-tools validated successfully
+    func testCmdlineToolsValidationSucceedsWhenPresent() async throws {
+        // Create Android SDK with cmdline-tools
+        let androidHome = mockEnv.androidHome
+        let sdkmanagerPath = "\(androidHome)/cmdline-tools/latest/bin/sdkmanager"
+        try mockEnv.createMockScript(at: sdkmanagerPath, echoing: "20.0")
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        let (result, messages) = try await runValidator { queue in
+            try await validateCmdlineTools(
+                command: command,
+                androidHome: androidHome,
+                javaHome: mockEnv.javaHome,
+                environment: env,
+                out: queue
+            )
+        }
+
+        XCTAssertFalse(result.wasBootstrapped)
+        XCTAssertEqual(result.version, "20.0")
+        XCTAssertEqual(result.sdkmanagerPath, sdkmanagerPath)
+        // StreamingCommand.run() generates a message block with timing info,
+        // and validateCmdlineTools adds its own message
+        XCTAssertGreaterThanOrEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.status, MessageBlock.Status.pass)
+    }
+
+    /// No sdkmanager found anywhere
+    func testCmdlineToolsNotFoundAnywhereFails() async throws {
+        let androidHome = mockEnv.androidHome
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await validateCmdlineTools(
+                    command: command,
+                    androidHome: androidHome,
+                    javaHome: self.mockEnv.javaHome,
+                    environment: env,
+                    out: queue
+                )
+            }}
+        ) { error in
+            XCTAssertTrue(error is CmdlineToolsNotFoundError)
+        }
+    }
+
+    // MARK: - AVD Existence Check Tests
+
+    /// AVD doesn't exist - should allow creation
+    func testCheckAVDExistsReturnsFalseWhenNoAVD() async throws {
+        let androidHome = mockEnv.androidHome
+
+        // Create mock emulator script that returns empty AVD list
+        try mockEnv.createMockScript(at: mockEnv.emulatorPath, echoing: "")
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        let (result, messages) = try await runValidator { queue in
+            try await checkAVDExists(
+                command: command,
+                androidHome: androidHome,
+                environment: env,
+                avdName: "TestAVD",
+                out: queue
+            )
+        }
+
+        XCTAssertFalse(result)
+        // StreamingCommand.run() generates a message block with timing info
+        XCTAssertEqual(messages.count, 1)
+    }
+
+    /// AVD exists - should skip creation
+    func testCheckAVDExistsReturnsTrueWhenPresent() async throws {
+        let androidHome = mockEnv.androidHome
+
+        // Create mock emulator script that returns list including TestAVD
+        try mockEnv.createMockScript(at: mockEnv.emulatorPath, echoing: """
+            OtherAVD
+            TestAVD
+            AnotherAVD
+            """)
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        let (result, _) = try await runValidator { queue in
+            try await checkAVDExists(
+                command: command,
+                androidHome: androidHome,
+                environment: env,
+                avdName: "TestAVD",
+                out: queue
+            )
+        }
+
+        XCTAssertTrue(result)
+    }
+
+    /// AVD with similar name exists - should not match partial names
+    func testCheckAVDExistsReturnsFalseForDifferentName() async throws {
+        let androidHome = mockEnv.androidHome
+
+        // Create mock emulator script that returns other AVDs but not TestAVD
+        try mockEnv.createMockScript(at: mockEnv.emulatorPath, echoing: """
+            OtherAVD
+            AnotherAVD
+            """)
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        let (result, _) = try await runValidator { queue in
+            try await checkAVDExists(
+                command: command,
+                androidHome: androidHome,
+                environment: env,
+                avdName: "TestAVD",
+                out: queue
+            )
+        }
+
+        XCTAssertFalse(result)
+    }
+
+    /// emulator command fails - should throw error, not assume no AVDs
+    func testCheckAVDExistsThrowsWhenCommandFails() async throws {
+        let androidHome = mockEnv.androidHome
+
+        // Create mock emulator script that fails with an error
+        try mockEnv.createMockScript(at: mockEnv.emulatorPath, content: "exit 1")
+
+        let env = mockEnv.environment()
+
+        let command = try TestMessageCommand.parse([])
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await checkAVDExists(
+                    command: command,
+                    androidHome: androidHome,
+                    environment: env,
+                    avdName: "TestAVD",
+                    out: queue
+                )
+            }}
+        ) { error in
+            XCTAssertTrue(error is EmulatorListAVDsError, "Expected EmulatorListAVDsError but got \(type(of: error))")
+            XCTAssertTrue(error.localizedDescription.contains("emulator -list-avds"))
+        }
+    }
+
+    // MARK: - Emulator Path Validation Tests
+
+    func testFindEmulatorPathSucceedsWhenPresent() async throws {
+        let androidHome = mockEnv.androidHome
+
+        try mockEnv.createMockScript(at: mockEnv.emulatorPath, echoing: "Android emulator version 34.2.0.0")
+
+        let (result, messages) = try await runValidator { queue in
+            try await findEmulatorPath(androidHome: androidHome, out: queue)
+        }
+
+        XCTAssertEqual(result, mockEnv.emulatorPath)
+        XCTAssertEqual(messages.count, 1)
+        XCTAssertEqual(messages.first?.status, MessageBlock.Status.pass)
+    }
+
+    /// Emulator binary not found - should fail with clear error
+    func testFindEmulatorPathFailsWhenMissing() async {
+        let androidHome = mockEnv.androidHome
+        try? FileManager.default.createDirectory(atPath: androidHome, withIntermediateDirectories: true)
+
+        await XCTAssertThrowsErrorAsync(
+            { _ = try await runValidator { queue in
+                try await findEmulatorPath(androidHome: androidHome, out: queue)
+            }}
+        ) { error in
+            XCTAssertTrue(error is EmulatorNotFoundError)
+        }
+    }
+    
+    // MARK: - Integration Test
+    
+    /// Test AndroidEmulatorCreateCommand.performCommand validates environment
+    /// Uses a bootstrap SDK manager that generates sdkmanager, avdmanager, and emulator
+    func testAndroidEmulatorCreateCommandPerformCommand() async throws {
+        let androidHome = mockEnv.androidHome
+
+        // Create the ANDROID_HOME directory (required for validation)
+        try FileManager.default.createDirectory(atPath: androidHome, withIntermediateDirectories: true)
+
+        // Create bootstrap sdkmanager (also creates avdmanager and emulator as bootstrap scripts)
+        try mockEnv.createMockBootstrapSdkmanager()
+
+        try mockEnv.createMockJava(version: "17.0.8")
+
+        let env = mockEnv.environment()
+
+        var command = try AndroidEmulatorCreateCommand.parse([])
+        command.env = env
+
+        let stream = MessageStream { continuation in
+            Task {
+                let messageQueue = MessageQueue(retain: true, continuation: continuation)
+                do {
+                    try await command.performCommand(with: messageQueue)
+                    await messageQueue.finish()
+                } catch {
+                    await messageQueue.finish(throwing: error)
+                }
+            }
+        }
+
+        var messages: [String] = []
+        for try await message in stream {
+            if let msg = message.message(term: .plain) {
+                messages.append(msg)
+            }
+        }
+
+        XCTAssertGreaterThan(messages.count, 0, "performCommand should generate messages")
+        let javaMessages = messages.filter { $0.contains("Java") || $0.contains("java") }
+        XCTAssertGreaterThan(javaMessages.count, 0, "Java validation should run")
+        let androidHomeMessages = messages.filter { $0.contains("ANDROID_HOME") }
+        XCTAssertGreaterThan(androidHomeMessages.count, 0, "ANDROID_HOME validation should run")
+    }
+}


### PR DESCRIPTION
Fixes #187

1. Ensure we always pass `sdkmanager` and `avdmanager` a valid `JAVA_HOME`, because the stock cmdline-tools don't include one, and fails outright if the `/usr/bin/java` isn't set up. We're working around https://github.com/skiptools/homebrew-skip/issues/1

    Our Homebrew cask installs the `openjdk` formula, which does _not_ symlink into `/Library/Java/JavaVirtualMachines`. So that'll work, but only if we pass `JAVA_HOME` every time we want to use `sdkmanager` or `avdmanager`.
2. Ensure that we have a valid `ANDROID_HOME` (from the environment, or by guessing the path to Android Studio's SDK)
3. Check to see if cmdline-tools are installed in `ANDROID_HOME`; Android Studio doesn't install them by default
4. If cmdline-tools are not installed, we can "bootstrap" them by running _any_ `sdkmanager` we can find.

    Our Homebrew cask installs `android-commandlinetools`, which installs its own Android SDK (probably _not_ the one the user wants to use). We can use that (passing in `JAVA_HOME`), to run `sdkmanager --sdk_root=$ANDROID_HOME "cmdline-tools;latest"` to install the command line tools into Android Studio's SDK; then we can use the cmdline-tools in `ANDROID_HOME`.
5. At that point, we have a known-good `sdkmanager` in ANDROID_HOME, which we can use to install platform-tools, the target Android platform, and the emulator.
6. We ask `emulator` for the list of AVDs, skipping creating the AVD if it already exists. (Despite the claim of `--force`, in my experiments, I found that it wasn't able to overwrite an existing AVD, e.g. to change the system_image.)
7. If there's no existing emulator with that name, we can finally create the emulator with a known-good `avdmanager` in `ANDROID_HOME`'s `cmdline-tools`.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

I had Cursor generate the scaffolding for the tests and the implementation, but then I pretty much rewrote the whole thing by hand. 🤪 Having all of the tests gives me a lot of confidence that this code is robust.

-----

