### PR TITLE
Fix noisy logging in `swift test`

### DIFF
--- a/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
+++ b/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
@@ -205,6 +205,7 @@ extension XCTestCase {
             }
         } else {
             messages.forEach { print("Received expected message: \($0)") }
+            fflush(stdout)
         }
 
         // if we spcify to fork the kotlinc compiler, proceed with evaluating and comparing the results
@@ -232,6 +233,7 @@ extension XCTestCase {
         let messages = try await transpile(preflight: preflight, files: [tmpFile], isSwiftBridge: isSwiftBridge, transformers: transformers)
         XCTAssertTrue(!messages.isEmpty)
         messages.forEach { print("Received expected message: \($0)") }
+        fflush(stdout)
     }
 
     /// Transpiles the code without performing checks, e.g. for performance profiling.


### PR DESCRIPTION
When I run `swift test` on the main branch, the tail of the output looks like this, super noisy. On my Terminal, the actual test result is pushed off the screen, and all you can see is the rump Swift Testing result (0 tests) at the end, which is quite confusing. This PR adds `fflush`, so the messages appear earlier in the log, leaving the summary nice and clear.

## Before

<details><summary>Long logged messages</summary>
<p>

> Test Suite 'All tests' passed at 2026-02-27 19:36:41.426.
> 	 Executed 821 tests, with 0 failures (0 unexpected) in 8.862 (8.943) seconds
> embers", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/10985854-6057-4449-8F47-B7CD59329E45/Support.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 1, column: 1), end: SkipSyntax.Source.Position(line: 4, column: 1))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "This extension cannot be merged into its extended Kotlin type, because its type is defined outside of this module. Therefore it cannot add additional protocols", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/035C1799-1A39-498C-A639-77F992B4D2F9/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 1, column: 1), end: SkipSyntax.Source.Position(line: 4, column: 1))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "This extension cannot be merged into its extended Kotlin type, because its type is defined outside of this module. Therefore it cannot add additional constructors", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/1F1A91E2-672D-4906-8CF3-63E13FCB7E32/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 2, column: 5), end: SkipSyntax.Source.Position(line: 2, column: 16))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "Swift and Kotlin treat types nested within generic types in incompatible ways, and Skip cannot translate between the two. Consider moving this type out of its generic outer type", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/01828E1A-C081-49AA-A5F9-4BAC79053E48/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 4, column: 5), end: SkipSyntax.Source.Position(line: 11, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "This extension cannot be merged into its extended Kotlin type definition because it has generic constraints. Therefore it can add new properties and functions, but it cannot be used to override members or implement protocol requirements", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/D7D0444F-15E7-4FB1-82DC-A7754C95BDE5/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 6, column: 5), end: SkipSyntax.Source.Position(line: 7, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "This extension cannot be merged into its extended Kotlin type definition because it has generic constraints. Therefore it can add new properties and functions, but it cannot be used to override members or implement protocol requirements", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/B5DFECDE-3195-43AD-8568-20F89CC20661/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 6, column: 5), end: SkipSyntax.Source.Position(line: 7, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "Skip does not support type declarations within functions. Consider making this an independent type", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/37E56565-CDD8-41C9-958F-9D4C1F20E22B/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 2, column: 5), end: SkipSyntax.Source.Position(line: 4, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "Skip only supports OptionSets that are structs. Change this type to a struct", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/D4ED9612-0175-4064-8FFD-21A1894D0C97/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 1, column: 1), end: SkipSyntax.Source.Position(line: 10, column: 1))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.warning, message: "Kotlin does not support protocol members with lower visibility than their declaring protocol. Skip will elevate the visibility of this member, which may cause problems if it exposes internal types", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/CDCC0EE9-B286-43EA-B963-A7176392E338/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 4, column: 5), end: SkipSyntax.Source.Position(line: 5, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "This extension cannot be merged into its extended Kotlin type definition because it has generic constraints. Therefore the extension can only include properties and functions", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/443398FD-595B-4194-B539-85D5F92F4A2B/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 4, column: 5), end: SkipSyntax.Source.Position(line: 5, column: 5))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.warning, message: "Detected possible string mutation. This may cause errors when converting to Kotlin, which does not have mutable strings\n    s.append(\"foo\")\n      ^~~~~~", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/8FC72FBA-29B4-41C7-9258-A2F7886602AF/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 3, column: 7), end: SkipSyntax.Source.Position(line: 3, column: 12))))
> Received expected message: Message(kind: SkipSyntax.Message.Kind.error, message: "Kotlin typealias declarations do not support constrained generic types", sourceFile: Optional(SkipSyntax.Source.FilePath(path: "/var/folders/1l/jbmc3w7947x9ljkj_260bmrc0000gn/T//SkipSyntaxTests/8F7D4B6F-BDB3-45D8-81E5-D51EDF86372F/Source.swift")), sourceRange: Optional(SkipSyntax.Source.Range(start: SkipSyntax.Source.Position(line: 1, column: 1), end: SkipSyntax.Source.Position(line: 1, column: 58))))
> 􀟈  Test run started.
> 􀄵  Testing Library Version: 1501
> 􀄵  Target Platform: arm64e-apple-macos14.0
> 􁁛  Test run with 0 tests in 0 suites passed after 0.001 seconds.

</p>
</details> 

## After

```
Test Suite 'All tests' passed at 2026-02-27 20:00:57.898.
	 Executed 821 tests, with 0 failures (0 unexpected) in 8.978 (9.052) seconds
􀟈  Test run started.
􀄵  Testing Library Version: 1501
􀄵  Target Platform: arm64e-apple-macos14.0
􁁛  Test run with 0 tests in 0 suites passed after 0.001 seconds.
```


Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

