### PR TITLE
Handle copy-style resource bundles preserving folder hierarchy

### DIFF
--- a/Sources/SkipBuild/Commands/TranspileCommand.swift
+++ b/Sources/SkipBuild/Commands/TranspileCommand.swift
@@ -208,6 +208,13 @@ struct TranspileCommand: TranspilePhase, StreamingCommand {
 
         let _ = primaryModulePath
 
+        /// A collected resource entry with its URLs and mode
+        struct ResourceEntry {
+            let path: String
+            let urls: [URL]
+            let isCopyMode: Bool
+        }
+
         func buildSourceList() throws -> (sources: [URL], resources: [URL]) {
             let projectBaseURL = projectFolderPath.asURL
             let allProjectFiles: [URL] = try FileManager.default.enumeratedURLs(of: projectBaseURL)
@@ -289,6 +296,22 @@ struct TranspileCommand: TranspilePhase, StreamingCommand {
         // load and merge each of the skip.yml files for the dependent modules
         let (baseSkipConfig, mergedSkipConfig, configMap) = try loadSkipConfig(merge: true)
         let hasSkipFuse = configMap.keys.contains("SkipFuse")
+
+        // Build resource entries from skip.yml configuration, falling back to the default Resources/ folder
+        let resourceEntries: [ResourceEntry] = try {
+            let projectBaseURL = projectFolderPath.asURL
+            if let resourceConfigs = baseSkipConfig.skip?.resources {
+                return try resourceConfigs.map { config in
+                    let resourceDirURL = projectBaseURL.appendingPathComponent(config.path, isDirectory: true)
+                    let urls: [URL] = try FileManager.default.enumeratedURLs(of: resourceDirURL)
+                    return ResourceEntry(path: config.path, urls: urls, isCopyMode: config.isCopyMode)
+                }
+            } else if !resourceURLs.isEmpty {
+                return [ResourceEntry(path: "Resources", urls: resourceURLs, isCopyMode: false)]
+            } else {
+                return []
+            }
+        }()
 
         func moduleMode(for moduleName: String?) -> ModuleMode {
             let moduleMode: String?
@@ -1034,45 +1057,90 @@ struct TranspileCommand: TranspilePhase, StreamingCommand {
                 .appending(components: packageName.split(separator: ".").map(\.description))
                 .appending(component: "Resources")
 
-            for resourceFile in resourceURLs.map(\.path).sorted() {
-                let resourceFileCanonical = (resourceFile as NSString).standardizingPath
-                guard let resourceSourceURL = moduleNamePaths.compactMap({ (_, folder) -> URL? in
-                    let folderCanonical = (folder as NSString).standardizingPath
-                    guard resourceFileCanonical.hasPrefix(folderCanonical) else { return nil }
-                    let relativePath = String(resourceFileCanonical.dropFirst(folderCanonical.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-                    return URL(fileURLWithPath: relativePath, relativeTo: URL(fileURLWithPath: folderCanonical, isDirectory: true))
-                }).first else {
-                    // skip over resources that are not contained within the Resources/ folder (such as files in the Skip/ folder, which contain metadata that should not be copied)
-                    msg(.trace, "no module root parent for \(resourceFile)")
-                    continue
+            for entry in resourceEntries {
+                if entry.isCopyMode {
+                    try linkCopyResources(entry: entry, resourcesBasePath: resourcesBasePath)
+                } else {
+                    try linkProcessResources(entry: entry, resourcesBasePath: resourcesBasePath)
                 }
+            }
 
-                let sourcePath = try AbsolutePath(validating: resourceSourceURL.path)
+            /// Links resources in "copy" mode, preserving the directory hierarchy relative to the resource folder
+            func linkCopyResources(entry: ResourceEntry, resourcesBasePath: AbsolutePath) throws {
+                for resourceFile in entry.urls.map(\.path).sorted() {
+                    let resourceFileCanonical = (resourceFile as NSString).standardizingPath
+                    guard let resourceSourceURL = moduleNamePaths.compactMap({ (_, folder) -> URL? in
+                        let folderCanonical = (folder as NSString).standardizingPath
+                        guard resourceFileCanonical.hasPrefix(folderCanonical) else { return nil }
+                        let relativePath = String(resourceFileCanonical.dropFirst(folderCanonical.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                        return URL(fileURLWithPath: relativePath, relativeTo: URL(fileURLWithPath: folderCanonical, isDirectory: true))
+                    }).first else {
+                        msg(.trace, "no module root parent for \(resourceFile)")
+                        continue
+                    }
 
+                    let sourcePath = try AbsolutePath(validating: resourceSourceURL.path)
+                    let resourceComponents = try RelativePath(validating: resourceSourceURL.relativePath).components
 
-                let resourceComponents = try RelativePath(validating: resourceSourceURL.relativePath).components
-                // all resources get put into a single "Resources/" folder in the jar, so drop the first item and replace it with "Resources/"
-                let components = resourceComponents.dropFirst(1)
-                let resourceSourcePath = try RelativePath(validating: components.joined(separator: "/"))
+                    // In copy mode, preserve the full directory hierarchy including the resource folder name
+                    // (e.g., "ResourcesCopy/subdir/file.txt"), matching Darwin's .copy() behavior where
+                    // the folder name becomes a subdirectory in the bundle.
+                    let resourceSourcePath = try RelativePath(validating: resourceComponents.joined(separator: "/"))
+                    let destinationPath = resourcesBasePath.appending(resourceSourcePath)
 
-                if sourcePath.parentDirectory.basename == buildSrcFolderName {
-                    trace("skipping resource linking for buildSrc/")
-                } else if isCMakeProject {
-                    trace("skipping resource linking for CMake project")
-                } else if sourcePath.extension == "xcstrings" {
-                    try convertStrings(resourceSourceURL: resourceSourceURL, sourcePath: sourcePath)
-                //} else if sourcePath.extension == "xcassets" {
-                    // TODO: convert various assets into Android res/ folder
-                } else { // non-processed resources are just linked directly from the package
-                    // the Android "res" folder is special: it is intended to store Android-specific resources like values/strings.xml, and will be linked into the archive's res/ folder
-                    let isAndroidRes = resourceComponents.first == "res"
-                    let destinationPath = (isAndroidRes ? resOutputFolder : resourcesBasePath).appending(resourceSourcePath)
-
-                    // only create links for files that exist
-                    if fs.isFile(sourcePath) {
-                        info("\(destinationPath.relative(to: moduleBasePath).pathString) linking to \(sourcePath.pathString)", sourceFile: sourcePath.sourceFile)
+                    if sourcePath.parentDirectory.basename == buildSrcFolderName {
+                        trace("skipping resource linking for buildSrc/")
+                    } else if isCMakeProject {
+                        trace("skipping resource linking for CMake project")
+                    } else if fs.isFile(sourcePath) {
+                        info("\(destinationPath.relative(to: moduleBasePath).pathString) copying to \(sourcePath.pathString)", sourceFile: sourcePath.sourceFile)
                         try fs.createDirectory(destinationPath.parentDirectory, recursive: true)
                         try addLink(destinationPath, pointingAt: sourcePath, relative: false)
+                    }
+                }
+            }
+
+            /// Links resources in "process" mode, flattening the hierarchy and performing special processing for .xcstrings and other files
+            func linkProcessResources(entry: ResourceEntry, resourcesBasePath: AbsolutePath) throws {
+                for resourceFile in entry.urls.map(\.path).sorted() {
+                    let resourceFileCanonical = (resourceFile as NSString).standardizingPath
+                    guard let resourceSourceURL = moduleNamePaths.compactMap({ (_, folder) -> URL? in
+                        let folderCanonical = (folder as NSString).standardizingPath
+                        guard resourceFileCanonical.hasPrefix(folderCanonical) else { return nil }
+                        let relativePath = String(resourceFileCanonical.dropFirst(folderCanonical.count)).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+                        return URL(fileURLWithPath: relativePath, relativeTo: URL(fileURLWithPath: folderCanonical, isDirectory: true))
+                    }).first else {
+                        // skip over resources that are not contained within the resource folder
+                        msg(.trace, "no module root parent for \(resourceFile)")
+                        continue
+                    }
+
+                    let sourcePath = try AbsolutePath(validating: resourceSourceURL.path)
+
+                    let resourceComponents = try RelativePath(validating: resourceSourceURL.relativePath).components
+                    // all resources get put into a single "Resources/" folder in the jar, so drop the first item and replace it with "Resources/"
+                    let components = resourceComponents.dropFirst(1)
+                    let resourceSourcePath = try RelativePath(validating: components.joined(separator: "/"))
+
+                    if sourcePath.parentDirectory.basename == buildSrcFolderName {
+                        trace("skipping resource linking for buildSrc/")
+                    } else if isCMakeProject {
+                        trace("skipping resource linking for CMake project")
+                    } else if sourcePath.extension == "xcstrings" {
+                        try convertStrings(resourceSourceURL: resourceSourceURL, sourcePath: sourcePath)
+                    //} else if sourcePath.extension == "xcassets" {
+                        // TODO: convert various assets into Android res/ folder
+                    } else { // non-processed resources are just linked directly from the package
+                        // the Android "res" folder is special: it is intended to store Android-specific resources like values/strings.xml, and will be linked into the archive's res/ folder
+                        let isAndroidRes = resourceComponents.first == "res"
+                        let destinationPath = (isAndroidRes ? resOutputFolder : resourcesBasePath).appending(resourceSourcePath)
+
+                        // only create links for files that exist
+                        if fs.isFile(sourcePath) {
+                            info("\(destinationPath.relative(to: moduleBasePath).pathString) linking to \(sourcePath.pathString)", sourceFile: sourcePath.sourceFile)
+                            try fs.createDirectory(destinationPath.parentDirectory, recursive: true)
+                            try addLink(destinationPath, pointingAt: sourcePath, relative: false)
+                        }
                     }
                 }
             }

--- a/Sources/SkipBuild/SkipConfig.swift
+++ b/Sources/SkipBuild/SkipConfig.swift
@@ -32,6 +32,8 @@ struct TranspilationConfig : Codable {
     var bridging: Either<Bool>.Or<BridgeConfig>?
     /// Namespace for code gen of dynamic types
     var dynamicroot: String?
+    /// Resource declarations with optional mode ("process" or "copy")
+    var resources: [ResourceConfig]?
 
     func isAutoBridgingEnabled() -> Bool {
         switch bridging {
@@ -79,4 +81,17 @@ struct BridgeConfig : Equatable, Codable {
 
 enum BridgeOption: String {
     case kotlincompat
+}
+
+/// Configuration for a resource directory in skip.yml
+struct ResourceConfig : Equatable, Codable {
+    /// The path to the resource directory, relative to the module source folder
+    var path: String
+    /// The resource processing mode: "process" (default) flattens and processes localization files; "copy" preserves the directory hierarchy as-is
+    var mode: String?
+
+    /// Whether this resource should be copied without any processing
+    var isCopyMode: Bool {
+        mode == "copy"
+    }
 }


### PR DESCRIPTION
Skip currently only handles the `resources: [.process("Resources")]` style of resource, whereby the contents of the folder are processed in an iOS-style fashion: localization files are transformed, image assets are processed, etc. This works file for plain resources that are to be accessed manually at runtime with `Bundle.module.url(forResource: …)` (like data and text files), but has the limitation that all folder hierarchies are "flattened", making it impossible to organize assets by sub-folder.

This PR addresses this limitation by adding support for copy-style resources, a la `resources: [.process("my-stuff")]`, whose contents can be accessed with `Bundle.module.url(forResource: "my-stuff/some/full/path/file.data")`. The caveat is that since the SwiftPM plugin API does not provide any information about the resources of a given SwiftPM module, the information about the resource configuration needs to also be listed in the module's `skip.yml`, like so:

```
skip:
  resources:
    - path: 'Resources'
      mode: 'process'
    - path: 'my-stuff'
      mode: 'copy'
```

The documentation at https://skip.dev/docs/development-topics/#resource-modes will be updated to describe this requirement.

Fixes https://github.com/skiptools/skip-ui/issues/79, fixes https://github.com/skiptools/skip-ui/issues/269

