### PR TITLE
Added support for .strings and .stringsdict files

### DIFF
--- a/Sources/SkipBuild/Commands/SkipstoneCommand.swift
+++ b/Sources/SkipBuild/Commands/SkipstoneCommand.swift
@@ -1170,7 +1170,7 @@ struct SkipstoneCommand: BuildPluginOptionsCommand, StreamingCommand {
             }
 
             func copyStrings(resourceSourceURL: URL, sourcePath: AbsolutePath) throws {
-                // process the .strings / .stringsdict in the same way that Xcode does: parse the FILE and use the content to synthesize a LANG.lproj/TABLENAME.EXTENSION file
+                // process the .strings / .stringsdict in the same way that Xcode does: read the FILE and use the content to synthesize a LANG.lproj/TABLENAME.EXTENSION file
                 let content = try Data(contentsOf: resourceSourceURL)
 
                 let localeId = sourcePath.parentDirectory.basenameWithoutExt


### PR DESCRIPTION
This PR improves support for localized strings by also copying the `*.strings` and `*.stringsdict` files to the resources.

This is particularly useful for projects that haven’t yet adopted to the `*.xcstrings` format. For instance, I still prefer using the `*.lproj` structure for open-source repositories as they are much easier to review in Git diffs and allow contributors to assist with translations without needing specialized tools or dealing with the complex JSON structure of `*.xcstrings`.

During the adjustment, the following question also came into my mind:
As I’ve noticed, the plural variants from the `*.xcstrings `files are already converted internally into `*.stringsdict` files. However, according to the [documentation](https://skip.dev/docs/development-topics/#localization), these are currently not supported. Is this still planned, or is it technically not possible? I’ve already looked into the Skip Foundation to see how the mapping of localized strings currently works, but I haven’t found a solution on how to support it yet. But maybe I just don't have the necessary background knowledge.

Looking forward to your response! 😊

---

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

