### PR TITLE
Add SkipFuse as explicit dependency for native app modules

### DIFF
--- a/Sources/SkipBuild/SkipProject.swift
+++ b/Sources/SkipBuild/SkipProject.swift
@@ -1353,6 +1353,7 @@ struct TestData : Codable, Hashable {
                 if isAppModule {
                     if isNativeAppModule {
                         modDeps.append(PackageModule(repositoryName: "skip-fuse-ui", moduleName: "SkipFuseUI"))
+                        modDeps.append(PackageModule(repositoryName: "skip-fuse", moduleName: "SkipFuse"))
                     } else {
                         modDeps.append(PackageModule(repositoryName: "skip-ui", moduleName: "SkipUI"))
                     }

--- a/Tests/SkipBuildTests/SkipCommandTests.swift
+++ b/Tests/SkipBuildTests/SkipCommandTests.swift
@@ -1255,7 +1255,8 @@ final class SkipCommandTests: XCTestCase {
             targets: [
                 .target(name: "AppModule", dependencies: [
                     "ModelModule",
-                    .product(name: "SkipFuseUI", package: "skip-fuse-ui")
+                    .product(name: "SkipFuseUI", package: "skip-fuse-ui"),
+                    .product(name: "SkipFuse", package: "skip-fuse")
                 ], resources: [.process("Resources")], plugins: [.plugin(name: "skipstone", package: "skip")]),
                 .target(name: "ModelModule", dependencies: [
                     .product(name: "SkipFuse", package: "skip-fuse"),
@@ -1362,11 +1363,13 @@ final class SkipCommandTests: XCTestCase {
             ],
             dependencies: [
                 .package(url: "https://source.skip.tools/skip.git", from: "1.0.0"),
-                .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0")
+                .package(url: "https://source.skip.tools/skip-fuse-ui.git", from: "1.0.0"),
+                .package(url: "https://source.skip.tools/skip-fuse.git", from: "1.0.0")
             ],
             targets: [
                 .target(name: "AppModule", dependencies: [
-                    .product(name: "SkipFuseUI", package: "skip-fuse-ui")
+                    .product(name: "SkipFuseUI", package: "skip-fuse-ui"),
+                    .product(name: "SkipFuse", package: "skip-fuse")
                 ], resources: [.process("Resources")], plugins: [.plugin(name: "skipstone", package: "skip")]),
             ]
         )


### PR DESCRIPTION
Starting from Xcode 26, Swift Explicit Modules is enabled by default, requiring all imported modules to be declared as explicit dependencies.
(ref: https://developer.apple.com/documentation/xcode-release-notes/xcode-26-release-notes#Resolved-Issues)

The generated Package.swift for Skip Fuse mode now includes skip-fuse alongside skip-fuse-ui, fixing `import SkipFuse` failures.

Fixes skiptools/skip#662

Thank you for contributing to the Skip project! Please use this space to describe your change and add any labels (bug, enhancement, documentation, etc.) to help categorize your contribution.

Please review the contribution guide at https://skip.dev/docs/contributing/ for advice and guidance on making high-quality PRs.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

I used the issue I opened (skiptools/skip#662) to have Claude Code generate the fix, and verified it by running swift test.
However, it is difficult to perform a practical verification using skip create until this fix is merged into the main skip repository.