### PR TITLE
Add support for `@ScaledMetric`

### DIFF
--- a/Sources/SkipSyntax/HelperTypes.swift
+++ b/Sources/SkipSyntax/HelperTypes.swift
@@ -213,7 +213,7 @@ struct Attributes: Hashable, PrettyPrintable, Codable {
 
     /// Some property wrappers are non-mutating.
     var isNonMutating: Bool {
-        return contains(.appStorage) || contains(.bindable) || contains(.binding) || contains(.environment) || contains(.environmentObject) || contains(.focusState) || contains(.gestureState) || contains(.nonmutating) || contains(.observedObject) || contains(.state) || contains(.stateObject)
+        return contains(.appStorage) || contains(.bindable) || contains(.binding) || contains(.environment) || contains(.environmentObject) || contains(.focusState) || contains(.gestureState) || contains(.nonmutating) || contains(.observedObject) || contains(.scaledMetric) || contains(.state) || contains(.stateObject)
     }
 
     /// Convenience to retrieve any @Environment or @EnvironmentObject attribute.
@@ -317,6 +317,7 @@ struct Attribute: Hashable, Codable {
         case observationIgnored
         case observedObject
         case published
+        case scaledMetric
         case state
         case stateObject
         case suite
@@ -393,6 +394,8 @@ struct Attribute: Hashable, Codable {
             return .observedObject
         case "Published":
             return .published
+        case "ScaledMetric":
+            return .scaledMetric
         case "State":
             return .state
         case "StateObject":

--- a/Sources/SkipSyntax/Kotlin/KotlinStructTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinStructTransformer.swift
@@ -211,6 +211,13 @@ final class KotlinStructTransformer: KotlinTransformer {
                 }
                 let appStorageParameters = KotlinSwiftUITransformer.appStorageAdditionalInitParameters(for: variableDeclaration, codebaseInfo: translator.codebaseInfo)
                 assignment = "this._\(variableDeclaration.propertyName) = skip.ui.AppStorage(wrappedValue = \(value), \(appStorageParameters))"
+            } else if variableDeclaration.attributes.contains(.scaledMetric) {
+                var value = variableDeclaration.propertyName
+                if variableDeclaration.mayBeSharedMutableStruct {
+                    value += ".sref()"
+                }
+                let scaledMetricParameters = KotlinSwiftUITransformer.scaledMetricAdditionalInitParameters(for: variableDeclaration)
+                assignment = "this._\(variableDeclaration.propertyName) = skip.ui.ScaledMetric(wrappedValue = \(value)\(scaledMetricParameters))"
             } else if variableDeclaration.attributes.contains(.binding) {
                 assignment = "this._\(variableDeclaration.propertyName) = \(variableDeclaration.propertyName)"
             } else if variableDeclaration.attributes.contains(.bindable) || variableDeclaration.attributes.contains(.observedObject) {
@@ -330,7 +337,7 @@ final class KotlinStructTransformer: KotlinTransformer {
             bodyStatements += variableDeclarations.map { variableDeclaration in
                 if variableDeclaration.attributes.stateAttribute != nil {
                     return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = skip.ui.State(copy.\(variableDeclaration.propertyName))")
-                } else if variableDeclaration.attributes.contains(.appStorage) || variableDeclaration.attributes.contains(.binding) {
+                } else if variableDeclaration.attributes.contains(.appStorage) || variableDeclaration.attributes.contains(.binding) || variableDeclaration.attributes.contains(.scaledMetric) {
                     return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = copy._\(variableDeclaration.propertyName)")
                 } else if variableDeclaration.attributes.contains(.bindable) || variableDeclaration.attributes.contains(.observedObject) {
                     return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = skip.ui.Bindable(copy.\(variableDeclaration.propertyName))")
@@ -470,7 +477,7 @@ final class KotlinStructTransformer: KotlinTransformer {
         return storedVariableDeclarations.map { variableDeclaration in
             if variableDeclaration.attributes.stateAttribute != nil {
                 return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = skip.ui.State(\(copy).\(variableDeclaration.propertyName))")
-            } else if variableDeclaration.attributes.contains(.appStorage) || variableDeclaration.attributes.contains(.binding) {
+            } else if variableDeclaration.attributes.contains(.appStorage) || variableDeclaration.attributes.contains(.binding) || variableDeclaration.attributes.contains(.scaledMetric) {
                 return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = \(copy)._\(variableDeclaration.propertyName)")
             } else if variableDeclaration.attributes.contains(.bindable) || variableDeclaration.attributes.contains(.observedObject) {
                 return KotlinRawStatement(sourceCode: "this._\(variableDeclaration.propertyName) = skip.ui.Bindable(\(copy).\(variableDeclaration.propertyName))")

--- a/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
@@ -59,6 +59,15 @@ final class KotlinSwiftUITransformer: KotlinTransformer {
         return ret
     }
 
+    /// Return a string of the init parameters needed to construct a `ScaledMetric` after `wrappedValue`.
+    static func scaledMetricAdditionalInitParameters(for variableDeclaration: KotlinVariableDeclaration) -> String {
+        let tokens = variableDeclaration.attributes.of(kind: .scaledMetric).first?.tokens ?? []
+        guard let relativeTo = tokens.first else {
+            return ""
+        }
+        return ", relativeTo = \(relativeTo)"
+    }
+
     /// If the given variable is the `body` of a `View`, return the parent view.
     static func viewForBody(_ variableDeclaration: KotlinVariableDeclaration, codebaseInfo: CodebaseInfo.Context?) -> KotlinClassDeclaration? {
         guard variableDeclaration.role == .property, variableDeclaration.propertyName == "body", !variableDeclaration.isStatic, let classDeclaration = variableDeclaration.parent as? KotlinClassDeclaration else {
@@ -249,6 +258,8 @@ private final class TranslateVisitor {
                     return ("_" + variableName, "skip.ui.Environment")
                 } else if variable.attributes.contains(.focusState) {
                     return ("_" + variableName, "skip.ui.FocusState")
+                } else if variable.attributes.contains(.scaledMetric) {
+                    return ("_" + variableName, "skip.ui.ScaledMetric")
                 } else {
                     return nil
                 }
@@ -339,6 +350,7 @@ private final class TranslateVisitor {
         let bindingVariables = variableDeclarations.filter { $0.attributes.contains(.binding) }
         let bindableVariables = variableDeclarations.filter { $0.attributes.contains(.bindable) || $0.attributes.contains(.observedObject) }
         let appStorageVariables = variableDeclarations.filter { $0.attributes.contains(.appStorage) }
+        let scaledMetricVariables = variableDeclarations.filter { $0.attributes.contains(.scaledMetric) }
         if !stateVariables.isEmpty || !focusStateVariables.isEmpty || !environmentVariables.isEmpty || !appStorageVariables.isEmpty {
             let evaluateFunction = synthesizeEvaluateFunction(isModifier: isModifier, stateVariables: stateVariables, focusStateVariables: focusStateVariables, environmentVariables: environmentVariables, appStorageVariables: appStorageVariables)
             classDeclaration.insert(statements: [evaluateFunction], after: body)
@@ -363,6 +375,9 @@ private final class TranslateVisitor {
         }
         for appStorageVariable in appStorageVariables {
             synthesizeAppStorageBacking(variable: appStorageVariable)
+        }
+        for scaledMetricVariable in scaledMetricVariables {
+            synthesizeScaledMetricBacking(variable: scaledMetricVariable)
         }
     }
 
@@ -634,6 +649,35 @@ private final class TranslateVisitor {
             } else if variable.propertyType.isOptional {
                 output.append(" = skip.ui.AppStorage(null, ")
                 output.append(KotlinSwiftUITransformer.appStorageAdditionalInitParameters(for: variable, codebaseInfo: codebaseInfo))
+                output.append(")")
+            }
+            output.append("\n")
+        }
+        variable.storage = storage
+    }
+
+    /// Create the additional property synthesized for `@ScaledMetric` variables.
+    private func synthesizeScaledMetricBacking(variable: KotlinVariableDeclaration) {
+        // Tell the @ScaledMetric variable to get its value using _variable of type ScaledMetric
+        variable.apiFlags.options.remove(.writeable)
+        let storageName = "_\(variable.propertyName)"
+        var storage = KotlinVariableStorage()
+        storage.isSingleStatementAppendable = { _ in true }
+        storage.appendGet = { variable, sref, isSingleStatement, output, indentation in
+            if !isSingleStatement {
+                output.append(indentation).append("return ")
+            }
+            output.append(storageName).append(".wrappedValue")
+            sref()
+            output.append("\n")
+        }
+        storage.appendStorage = { variable, output, indentation in
+            let storageType = variable.propertyType.asPropertyWrapper("skip.ui.ScaledMetric").kotlin
+            output.append(indentation).append(variable.modifiers.kotlinMemberString(isGlobal: false, isOpen: false, suffix: " ")).append("var ").append(storageName).append(": ").append(storageType)
+            if let value = variable.value {
+                output.append(" = skip.ui.ScaledMetric(wrappedValue = ")
+                value.append(to: output, indentation: indentation)
+                output.append(KotlinSwiftUITransformer.scaledMetricAdditionalInitParameters(for: variable))
                 output.append(")")
             }
             output.append("\n")

--- a/Tests/SkipSyntaxTests/SwiftUITests.swift
+++ b/Tests/SkipSyntaxTests/SwiftUITests.swift
@@ -2486,6 +2486,42 @@ final class SwiftUITests: XCTestCase {
         """)
     }
 
+    func testScaledMetric() async throws {
+        try await check(supportingSwift: baseSupportingSwift, swift: """
+        import SwiftUI
+        struct V: View {
+            @ScaledMetric var scaledDemoPadding: Double = 8
+            var body: some View {
+                Text("A: \\(scaledDemoPadding)")
+            }
+        }
+        """, kotlin: """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.getValue
+        import androidx.compose.runtime.mutableStateOf
+        import androidx.compose.runtime.remember
+        import androidx.compose.runtime.saveable.Saver
+        import androidx.compose.runtime.saveable.rememberSaveable
+        import androidx.compose.runtime.setValue
+
+        import skip.ui.*
+        import skip.foundation.*
+        import skip.model.*
+        internal class V: View {
+            internal val scaledDemoPadding: Double
+                get() = _scaledDemoPadding.wrappedValue
+            internal var _scaledDemoPadding: skip.ui.ScaledMetric<Double>
+            override fun body(): View {
+                return ComposeBuilder { composectx: ComposeContext -> Text("A: ${scaledDemoPadding}").Compose(composectx) }
+            }
+
+            constructor(scaledDemoPadding: Double = 8.0) {
+                this._scaledDemoPadding = skip.ui.ScaledMetric(wrappedValue = scaledDemoPadding)
+            }
+        }
+        """)
+    }
+
     func testMainActorViewBody() async throws {
         let supportingSwift = """
         struct Task<Success, Failure> where Failure: Error {


### PR DESCRIPTION
* This PR is built to support https://github.com/skiptools/skip-ui/pull/394

The approach here was modeled based on `@AppStorage`.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this one completely. I tested it by testing my skip-ui PR in the Lite showcase and the Fuse showcase, and I visually reviewed the generated `testScaledMetric` to ensure that it looked sane.