### PR TITLE
Fix JNI arity for async closure bridge params

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -692,12 +692,13 @@ extension TypeSignature {
             return type.jni(options: options)
         case .float:
             return "F"
-        case .function(let parameters, let returnType, _, _):
+        case .function(let parameters, let returnType, let apiFlags, _):
             if isFunctionDeclaration {
                 let parametersJNI = parameters.map { $0.type.jni(options: options) }.joined(separator: "")
                 return "(" + parametersJNI + ")" + returnType.jni(options: options)
             } else {
-                return "Lkotlin/jvm/functions/Function\(parameters.count);"
+                let functionArity = apiFlags.options.contains(.async) ? parameters.count + 1 : parameters.count
+                return "Lkotlin/jvm/functions/Function\(functionArity);"
             }
         case .int, .uint:
             return "I"
@@ -1610,4 +1611,3 @@ private func checkNonTypedThrows(_ sourceDerived: SourceDerived?, apiFlags: APIF
     }
     return false
 }
-

--- a/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
@@ -4686,6 +4686,40 @@ final class BridgeToKotlinTests: XCTestCase {
         """, transformers: transformers)
     }
 
+    func testProtocolAsyncClosureParameterBridge() async throws {
+        let transformers = builtinKotlinTransformers() + [KotlinBridgeTransformer(options: .kotlincompat)]
+        try await check(swiftBridge: """
+        public protocol P {
+            func f(c: @escaping () async -> Void)
+        }
+        """, kotlin: """
+        interface P {
+            fun f(c: suspend () -> Unit)
+        }
+        """, swiftBridgeSupport: """
+        public final class P_BridgeImpl: P, BridgedFromKotlin {
+            nonisolated private static let Java_class = try! JClass(name: "P")
+            nonisolated public let Java_peer: JObject
+            nonisolated public required init(Java_ptr: JavaObjectPointer) {
+                Java_peer = JObject(Java_ptr)
+            }
+            public func f(c p_0: @escaping () async -> Void) {
+                jniContext {
+                    let p_0_java = SwiftAsyncClosure0.javaObject(for: p_0, options: [.kotlincompat])!.toJavaParameter(options: [.kotlincompat])
+                    try! Java_peer.call(method: Self.Java_f_0_methodID, options: [.kotlincompat], args: [p_0_java])
+                }
+            }
+            nonisolated private static let Java_f_0_methodID = Java_class.getMethodID(name: "f", sig: "(Lkotlin/jvm/functions/Function1;)V")!
+            nonisolated public static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                return .init(Java_ptr: obj!)
+            }
+            nonisolated public func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                return Java_peer.safePointer()
+            }
+        }
+        """, transformers: transformers)
+    }
+
     func testProtocolTypeMembers() async throws {
         try await check(swiftBridge: """
         public protocol P {


### PR DESCRIPTION
## Summary

Fix JNI signature generation for bridged async closure parameters.

When Skip generates a Swift bridge for a Kotlin interface method that takes a `suspend` closure, the generated JNI lookup was using `kotlin.jvm.functions.Function0` instead of `Function1`.

That is wrong because Kotlin `suspend () -> Unit` is compiled as a function that takes an extra continuation parameter, so its runtime shape is `Function1`.

In practice this caused generated bridges like `ClientWebSocket_Bridge.swift` to do:

```swift
Java_class.getMethodID(
    name: "createObserver",
    sig: "(Ljava/lang/String;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)Lcom/polymarket/clients/WSAppLifecycleObserver;"
)!
```

which returns nil, and then crashes when force-unwrapped.

## Root Cause
`TypeSignature.jni(...)` was computing Kotlin function arity from the declared Swift parameter count only.

That is correct for non-async closures, but incorrect for async closures, which need one extra slot for the continuation when bridged to Kotlin/JVM.

## Fix
When generating the JNI type for a function type outside a function declaration, increase the Kotlin function arity by 1 when the function type is async.

So bridged async closures now generate Function1 instead of Function0 for () async -> Void.

## Steps To Reproduce
- Add a bridged protocol method that accepts an async closure, for example:
```swift
public protocol P {
    func f(c: @escaping () async -> Void)
}
```
- Generate the bridge.

- Inspect the generated Swift bridge.

- Before this fix, the JNI signature lookup uses:

```swift
"(Lkotlin/jvm/functions/Function0;)V"
```
- That is incorrect for a Kotlin `suspend () -> Unit` parameter and can cause `getMethodID(...)` to return nil, leading to a crash.

After this fix, the generated signature is:

"(Lkotlin/jvm/functions/Function1;)V"
## Test Plan
- Added BridgeToKotlinTests.testProtocolAsyncClosureParameterBridge
- Ran:`swift test --filter BridgeToKotlinTests/testProtocolAsyncClosureParameterBridge`
- Verified downstream export/build against a real app using a local skip + local skipstone toolchain

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

