### PR TITLE
Fix skip android sdk install to use the latest released SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - run: skip welcome
 
       - name: "Upload Build Artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: skip-plugin-${{ runner.os }}
           path: artifacts/
@@ -143,7 +143,7 @@ jobs:
       - run: swift --version
 
       - name: "Download skip plugin"
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: skip-plugin-${{ runner.os }}
           path: skip-artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         swift:
-          - '6.3'
+          - '6.3.1'
         os:
           - 'ubuntu-latest'
           #- 'macos-latest'

--- a/Sources/SkipBuild/Commands/AndroidCommand.swift
+++ b/Sources/SkipBuild/Commands/AndroidCommand.swift
@@ -8,6 +8,7 @@ import FoundationNetworking
 #endif
 import ArgumentParser
 import TSCBasic
+import struct TSCUtility.Version
 import ELFKit
 #if canImport(SkipDriveExternal)
 import SkipDriveExternal
@@ -466,7 +467,9 @@ struct AndroidSDKInstallCommand: MessageCommand, ToolchainOptionsCommand {
         } else {
             // Look up the latest released Android SDK version
             let sdks = try await SwiftSDKOpenAPI.fetchSDKs(sdkName: "android")
-            guard let latest = sdks.first else {
+            // sort by semantic version so 6.3.1 > 6.3
+            let latestReleases = try? sdks.sorted(by: { try Version(versionString: $0.version, usesLenientParsing: true) < Version(versionString: $1.version, usesLenientParsing: true) })
+            guard let latest = latestReleases?.last ?? sdks.last else {
                 throw AndroidError(errorDescription: "No released Android SDK versions found")
             }
             resolvedVersion = latest.version


### PR DESCRIPTION
The release of Swift 6.3.1 (https://forums.swift.org/t/announcing-swift-6-3-1/) exposed two bugs in `skip android sdk install`:

1. We weren't fetching the _latest_ Android SDK by default, but rather the _first_. This PR fixes it so the highest available version is installed.
2. When installing the host toolchain, we use swiftly, which (unfortunately) interprets "6.3" as "6.3.LATEST_PATCH_VERSION".

The combination of these two issues causes a mismatch between the installed host toolchain (6.3.1) and the Swift SDK for Android (6.3), which leads to errors like:

```
<unknown>:0: error: module compiled with Swift 6.3 cannot be imported by the Swift 6.3.1 compiler: /Users/runner/Library/org.swift.swiftpm/swift-sdks/swift-6.3-RELEASE_android.artifactbundle/swift-android/swift-resources/usr/lib/swift-x86_64/android/Swift.swiftmodule/x86_64-unknown-linux-android.swiftmodule
```

This PR should fix both these issues. 