### PR TITLE
Fix `skip test` Swift testing

### DIFF
--- a/Sources/SkipBuild/Commands/TestCommand.swift
+++ b/Sources/SkipBuild/Commands/TestCommand.swift
@@ -113,6 +113,15 @@ extension TestCommand {
         }
     }
 
+    /// Next to the primary XCTest report, SwiftPM writes Swift Testing results to `<stem>-swift-testing.<ext>` when `--xunit-output` is passed as its own argument (not `--xunit-output=path`).
+    private func swiftTestingXUnitCompanionPath(xunitPath: String) -> String {
+        let url = URL(fileURLWithPath: xunitPath)
+        let directory = url.deletingLastPathComponent()
+        let stem = url.deletingPathExtension().lastPathComponent
+        let ext = url.pathExtension
+        return directory.appendingPathComponent("\(stem)-swift-testing.\(ext)").path
+    }
+
     func runTestCommand(with out: MessageQueue) async throws {
 
         // only run tests when there is a Tests/ folder
@@ -144,10 +153,19 @@ extension TestCommand {
         #if !canImport(SkipDriveExternal)
         throw SkipDriveError(errorDescription: "SkipDrive not linked")
         #else
-        // load the xunit results file
-        let xunitResults = try GradleDriver.TestSuite.parse(contentsOf: URL(fileURLWithPath: xunit))
-        if xunitResults.count == 0 {
-            throw SkipDriveError(errorDescription: "No test results found in \(xunit)")
+        // load XCTest XUnit and, when SwiftPM emits it, merge Swift Testing XUnit from the sibling file
+        let primaryXunitURL = URL(fileURLWithPath: xunit)
+        let primarySuites = try GradleDriver.TestSuite.parse(contentsOf: primaryXunitURL)
+        let swiftTestingPath = swiftTestingXUnitCompanionPath(xunitPath: xunit)
+        let swiftTestingSuites: [GradleDriver.TestSuite]
+        if FileManager.default.fileExists(atPath: swiftTestingPath) {
+            swiftTestingSuites = try GradleDriver.TestSuite.parse(contentsOf: URL(fileURLWithPath: swiftTestingPath))
+        } else {
+            swiftTestingSuites = []
+        }
+        let xunitResults = primarySuites + swiftTestingSuites
+        if xunitResults.flatMap(\.testCases).isEmpty {
+            throw SkipDriveError(errorDescription: "No test results found in \(xunit)" + (swiftTestingSuites.isEmpty ? "" : " or \(swiftTestingPath)"))
         }
 
         func testNameComparison(_ t1: TestCaseInfo, _ t2: TestCaseInfo) -> Bool {

--- a/Sources/SkipBuild/Commands/TestCommand.swift
+++ b/Sources/SkipBuild/Commands/TestCommand.swift
@@ -245,9 +245,16 @@ extension TestCommand {
                 let className = xunitCase.classname.split(separator: ".").last?.description ?? xunitCase.classname
                 let junitModuleCases = junitModuleCases(for: className)
 
+                // Swift Testing XUnit uses function-style names with "()", e.g. "add()"; JUnit Gradle output uses "add$SkipLib_debugUnitTest".
+                let junitMatchLabel = testName.hasSuffix("()") ? String(testName.dropLast(2)) : testName
                 // in JUnit, test names are sometimes the raw test name, and other times will be something like "testName$ModuleName_debugUnitTest"
                 // async tests are prefixed with "run"
-                let cases = junitModuleCases.filter({ $0.name == testName || $0.name.hasPrefix(testName + "$") || $0.name.hasPrefix("run" + testName + "$") })
+                let cases = junitModuleCases.filter({
+                    $0.name == testName
+                        || $0.name == junitMatchLabel
+                        || $0.name.hasPrefix(junitMatchLabel + "$")
+                        || $0.name.hasPrefix("run" + junitMatchLabel + "$")
+                })
                 if cases.count > 1 {
                     throw SkipDriveError(errorDescription: "Multiple conflicting XUnit and JUnit test cases named “\(testName)” in \(skipModule).")
                 }


### PR DESCRIPTION
Fixes #233 

There's a comment in here about a "fun fact" about `swift test`. When a project contains both XCTests and Swift Testing tests, `swift test --xunit-output=blah.xml` behaves differently from `swift test --xunit-output blah.xml` with a space instead of an equal sign. When there's a `=`, the resulting XML contains only Swift Testing results and no XCTest results. When there's a space instead of an equal sign, it generates XCTest results in `blah.xml` and generates Swift Testing results in `blah-swift-testing.xml`. (This is now filed as https://github.com/swiftlang/swift-package-manager/issues/9960 and I've filed a PR to fix it in https://github.com/swiftlang/swift-package-manager/pull/9962)

And another fun fact:
* https://github.com/swiftlang/swift-package-manager/issues/9961 

These SwiftPM issues quite nearly drove me insane during manual testing!

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor generated the code, but I did all the investigative work by hand. I tested the code by running it against `skip-lib`.