### PR TITLE
Don't rebuild when running tests

### DIFF
--- a/Sources/SkipBuild/Commands/TestCommand.swift
+++ b/Sources/SkipBuild/Commands/TestCommand.swift
@@ -131,8 +131,6 @@ extension TestCommand {
 
         let xunit = xunit ?? ".build/xcunit-\(UUID().uuidString).xml"
 
-        try await run(with: out, "Build Project", ["swift", "build", "--build-tests", "--verbose", "--configuration", configuration, "--package-path", project], additionalEnvironment: additionalEnv)
-
         var testResult: Result<ProcessOutput, Error>? = nil
         if test == true {
             testResult = try await run(with: out, "Test project", ["swift", "test", "--parallel", "-c", configuration, "--enable-code-coverage", "--xunit-output", xunit, "--package-path", project], additionalEnvironment: additionalEnv)


### PR DESCRIPTION
`skip test` was running `swift build` followed by `swift test`.

For some reason, `swift test` assumes that the build has to rerun from scratch with the flags that we're passing, so the `swift build` was a complete waste. (This doesn't happen when you just `swift build --build-tests` followed by `swift test` … the `--xunit-output` seems to be triggering it.)

Anyway, pre-building is a waste of time regardless, even if it's just a 10ms freshness check. This PR removes the pre-build step, letting `swift test` run the build.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

