### PR TITLE
Make `actor`s with `async` members use actor isolation

### DIFF
--- a/Sources/SkipSyntax/StatementTypes.swift
+++ b/Sources/SkipSyntax/StatementTypes.swift
@@ -1175,7 +1175,7 @@ final class FunctionDeclaration: Statement {
             }
         }
         generics = generics.resolved(in: self, context: context)
-        if asyncBehavior == .sync, type != .initDeclaration, !modifiers.isNonisolated && !modifiers.isStatic, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
+        if asyncBehavior != .actor, type != .initDeclaration, !modifiers.isNonisolated && !modifiers.isStatic, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
             asyncBehavior = .actor
         }
     }
@@ -1343,7 +1343,7 @@ final class SubscriptDeclaration: Statement {
             }
         }
         generics = generics.resolved(in: self, context: context)
-        if asyncBehavior == .sync, !modifiers.isNonisolated && !modifiers.isStatic, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
+        if asyncBehavior != .actor, !modifiers.isNonisolated && !modifiers.isStatic, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
             asyncBehavior = .actor
         }
     }
@@ -1949,7 +1949,7 @@ final class VariableDeclaration: Statement {
             }
         }
         throwsType = throwsType.resolved(in: self, context: context)
-        if asyncBehavior == .sync, !modifiers.isNonisolated && !modifiers.isStatic, !isLet, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
+        if asyncBehavior != .actor, !modifiers.isNonisolated && !modifiers.isStatic, !isLet, (parent as? TypeDeclaration)?.nonExtensionDeclarationType == .actorDeclaration {
             asyncBehavior = .actor
         }
     }

--- a/Tests/SkipSyntaxTests/ConcurrencyTests.swift
+++ b/Tests/SkipSyntaxTests/ConcurrencyTests.swift
@@ -1212,6 +1212,31 @@ final class ConcurrencyTests: XCTestCase {
         """)
     }
 
+    func testActorExplicitAsyncUsesActorRun() async throws {
+        try await check(swift: """
+        actor A {
+            func call() async {
+                call2()
+            }
+
+            func call2() async {
+                print(1)
+            }
+        }
+        """, kotlin: """
+        internal class A: Actor {
+            override val isolatedContext = Actor.isolatedContext()
+            internal suspend fun call(): Unit = Actor.run(this) {
+                call2()
+            }
+
+            internal suspend fun call2(): Unit = Actor.run(this) {
+                print(1)
+            }
+        }
+        """)
+    }
+
     func testActorAccess() async throws {
         try await check(supportingSwift: """
         actor A {


### PR DESCRIPTION
`AsyncBehavior` is an enum with three values: `.sync`, `.async`, and `.actor`. `.sync` member functions were using actor isolation, but `.async` member functions were not. Now, we'll set `asyncBehavior = .actor` as long as the `asyncBehavior` isn't already set to `.actor`.

Fixes https://github.com/skiptools/skip/issues/679

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [ ] OPTIONAL: I have tested my change on an iOS simulator or device
- [ ] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [x] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

Cursor did this one, including generating the unit test. I reviewed the unit test carefully, and used this build to test the repro for https://github.com/skiptools/skip/issues/679 to prove that it fixed it.