### PR TITLE
Fix transpilation of dollar sign escape in multi-line strings

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinExpressionTypes.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinExpressionTypes.swift
@@ -2603,7 +2603,7 @@ final class KotlinStringLiteral: KotlinExpression {
             for segment in expression.segments {
                 switch segment {
                 case .string(let string):
-                    let kstring = translateStringSegment(string)
+                    let kstring = translateStringSegment(string, isMultiline: expression.isMultiline)
                     if kstring == string, expression.segments.count == 1 {
                         swiftString = string
                     }
@@ -2623,7 +2623,7 @@ final class KotlinStringLiteral: KotlinExpression {
         return kexpression
     }
 
-    private static func translateStringSegment(_ string: String) -> String {
+    private static func translateStringSegment(_ string: String, isMultiline: Bool = false) -> String {
         var kstring = ""
         var backslashCount = 0
         var skipNextClosingBraceCount = 0
@@ -2649,8 +2649,15 @@ final class KotlinStringLiteral: KotlinExpression {
                 }
                 kstring.append(c)
             case "$":
-                kstring.append("\\")
-                kstring.append("$")
+                // Kotlin's backslash escape for `$` does not work inside
+                // triple-quoted (multiline) strings, so use the `${"$"}`
+                // template form instead. Single-line strings still use `\$`.
+                if isMultiline {
+                    kstring.append("${\"$\"}")
+                } else {
+                    kstring.append("\\")
+                    kstring.append("$")
+                }
             case "}":
                 if skipNextClosingBraceCount > 0 {
                     skipNextClosingBraceCount -= 1

--- a/Tests/SkipSyntaxTests/BuiltinTypeTests.swift
+++ b/Tests/SkipSyntaxTests/BuiltinTypeTests.swift
@@ -301,6 +301,66 @@ final class BuiltinTypeTests: XCTestCase {
         """)
     }
 
+    func testDollarSignEscape() async throws {
+        // Single-line strings can escape `$` with a backslash.
+        try await check(swift: """
+        "abc $xyz"
+        """, kotlin: """
+        "abc \\$xyz"
+        """)
+
+        try await check(swift: """
+        "It costs $5.00"
+        """, kotlin: """
+        "It costs \\$5.00"
+        """)
+
+        // Raw (multi-line) Kotlin strings: backslash escape of `$` does NOT work
+        // inside triple-quoted Kotlin strings, so the transpiler must emit the
+        // `${"$"}` template form instead.
+        try await check(swift: ##"#"$xyz"#"##, kotlin: ##""""${"$"}xyz""""##)
+
+        try await check(swift: ##"#"abc $xyz"#"##, kotlin: ##""""abc ${"$"}xyz""""##)
+
+        try await check(swift: ##"#"It costs $5.00"#"##, kotlin: ##""""It costs ${"$"}5.00""""##)
+
+        try await check(swift: ##"#"a $ b $$ c"#"##, kotlin: ##""""a ${"$"} b ${"$"}${"$"} c""""##)
+
+        // Raw string with literal backslash followed by `$`:
+        // Kotlin triple-quoted strings treat backslashes literally,
+        // so `\${"$"}` produces `\` + `$` in the resulting string.
+        try await check(swift: ##"#"\$xyz"#"##, kotlin: ##""""\${"$"}xyz""""##)
+
+        // Multi-line Swift triple-quoted string with `$`.
+        try await check(swift: """
+        let s = \"""
+            abc $xyz
+            \"""
+        """, kotlin: """
+        internal val s = \"""abc ${"$"}xyz""\"
+        """)
+
+        // Multi-line Swift string with `$` and an interpolation.
+        try await check(swift: """
+        let s = \"""
+            abc $xyz \\(foo)
+            \"""
+        """, kotlin: """
+        internal val s = \"""abc ${"$"}xyz ${foo}""\"
+        """)
+
+        // Multi-line Swift string spanning multiple lines with `$`.
+        try await check(swift: """
+        let s = \"""
+            abc
+            $xyz
+            \"""
+        """, kotlin: """
+        internal val s = \"""abc
+        ${"$"}xyz""\"
+        """)
+    }
+
     func testCharacterLiteral() async throws {
         try await check(swift: """
         let c1: Character = "a"


### PR DESCRIPTION
A swift string that contains a dollar-sign ("$") needs to escape the dollar sign to be correct on the Kotlin side (which uses it to mark an interpolation). We do this with a backslash, which works fine in single-line strings, but multi-line Kotlin strings do not treat the backslash as an escape, so the dollar tries to incorrectly interpolate the variable (typically resulting in an error).

This PR fixes it by changing the escape """some $literal dollar""" as """some ${"$"}literal dollar""", which is the common way to work around this issue in Kotlin.