### PR TITLE
Flatten recursive transpiler processing to prevent stack overflow

### DIFF
--- a/Sources/SkipBuild/Commands/SkipstoneCommand.swift
+++ b/Sources/SkipBuild/Commands/SkipstoneCommand.swift
@@ -1169,6 +1169,7 @@ struct SkipstoneCommand: BuildPluginOptionsCommand, StreamingCommand {
 
             func convertStrings(resourceSourceURL: URL, sourcePath: AbsolutePath) throws {
                 // process the .xcstrings in the same way that Xcode does: parse the JSON and use the localizations keys to synthesize a LANG.lproj/TABLENAME.strings file
+                // note that this is essentially the same thing that `/Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile` does as part of the resource processing for an Xcode build, so we could validate our output by comparing the results of that command to this process
                 let xcstrings = try JSONDecoder().decode(LocalizableStringsDictionary.self, from: Data(contentsOf: resourceSourceURL))
                 let defaultLanguage = xcstrings.sourceLanguage
                 let locales = Set(xcstrings.strings.values.compactMap(\.localizations?.keys).joined())

--- a/Sources/SkipSyntax/OutputGenerator.swift
+++ b/Sources/SkipSyntax/OutputGenerator.swift
@@ -41,6 +41,40 @@ public final class OutputGenerator {
         self.root = root
     }
 
+    /// Run a node's append method to capture its output as fragments.
+    ///
+    /// The node's `append(to:indentation:)` (or custom closure) executes, but every call
+    /// it makes to `output.append(...)` records a fragment rather than recursing or writing.
+    /// The result is a flat list: [leadingTrivia, beginNode, ...childFragments..., endNode].
+    private func recordNodeFragments(node: OutputNode, indentation: Indentation, customAppend: ((OutputGenerator) -> Void)? = nil) -> [Fragment] {
+        // Save the outer recording buffer so re-entrant calls don't clobber it.
+        let savedFragments = recordedFragments
+        recordedFragments = []
+
+        // Leading trivia.
+        let leading = node.leadingTrivia(indentation: indentation)
+        if !leading.isEmpty {
+            recordedFragments.append(.text(leading))
+        }
+
+        // Source mapping begin marker.
+        recordedFragments.append(.beginNode(node))
+
+        // Run the node's append logic — all its output.append() calls record fragments.
+        if let customAppend = customAppend {
+            customAppend(self)
+        } else {
+            node.append(to: self, indentation: indentation)
+        }
+
+        // Source mapping end marker (handles trailing trivia and offset computation).
+        recordedFragments.append(.endNode(node, indentation))
+
+        let result = recordedFragments
+        recordedFragments = savedFragments
+        return result
+    }
+
     func generateOutput(file: Source.FilePath) -> (output: Source, map: OutputMap) {
         // Seed the work stack with the root node.
         var workStack: [Fragment] = [.node(root, .zero)]
@@ -97,39 +131,6 @@ public final class OutputGenerator {
         return ret
     }
 
-    /// Run a node's append method to capture its output as fragments.
-    ///
-    /// The node's `append(to:indentation:)` (or custom closure) executes, but every call
-    /// it makes to `output.append(...)` records a fragment rather than recursing or writing.
-    /// The result is a flat list: [leadingTrivia, beginNode, ...childFragments..., endNode].
-    private func recordNodeFragments(node: OutputNode, indentation: Indentation, customAppend: ((OutputGenerator) -> Void)? = nil) -> [Fragment] {
-        // Save the outer recording buffer so re-entrant calls don't clobber it.
-        let savedFragments = recordedFragments
-        recordedFragments = []
-
-        // Leading trivia.
-        let leading = node.leadingTrivia(indentation: indentation)
-        if !leading.isEmpty {
-            recordedFragments.append(.text(leading))
-        }
-
-        // Source mapping begin marker.
-        recordedFragments.append(.beginNode(node))
-
-        // Run the node's append logic — all its output.append() calls record fragments.
-        if let customAppend = customAppend {
-            customAppend(self)
-        } else {
-            node.append(to: self, indentation: indentation)
-        }
-
-        // Source mapping end marker (handles trailing trivia and offset computation).
-        recordedFragments.append(.endNode(node, indentation))
-
-        let result = recordedFragments
-        recordedFragments = savedFragments
-        return result
-    }
 
     // MARK: - Public API (called by OutputNode.append implementations)
 

--- a/Sources/SkipSyntax/OutputGenerator.swift
+++ b/Sources/SkipSyntax/OutputGenerator.swift
@@ -31,11 +31,9 @@ public final class OutputGenerator {
         case endNode(OutputNode, Indentation)
     }
 
-    /// When true, calls to the public `append` methods record fragments
-    /// instead of writing to the output buffer or recursing.
-    private var isRecording = false
-
     /// Fragments accumulated during the current recording session.
+    /// The public `append` methods always record fragments here; the work loop
+    /// in `generateOutput` is responsible for processing them iteratively.
     private var recordedFragments: [Fragment] = []
 
     /// Supply node.
@@ -99,16 +97,14 @@ public final class OutputGenerator {
         return ret
     }
 
-    /// Run a node's append method in recording mode to capture its output as fragments.
+    /// Run a node's append method to capture its output as fragments.
     ///
     /// The node's `append(to:indentation:)` (or custom closure) executes, but every call
     /// it makes to `output.append(...)` records a fragment rather than recursing or writing.
     /// The result is a flat list: [leadingTrivia, beginNode, ...childFragments..., endNode].
     private func recordNodeFragments(node: OutputNode, indentation: Indentation, customAppend: ((OutputGenerator) -> Void)? = nil) -> [Fragment] {
-        // Save and enter recording mode (supports re-entrant recording for the 3-arg form).
-        let savedRecording = isRecording
+        // Save the outer recording buffer so re-entrant calls don't clobber it.
         let savedFragments = recordedFragments
-        isRecording = true
         recordedFragments = []
 
         // Leading trivia.
@@ -131,7 +127,6 @@ public final class OutputGenerator {
         recordedFragments.append(.endNode(node, indentation))
 
         let result = recordedFragments
-        isRecording = savedRecording
         recordedFragments = savedFragments
         return result
     }
@@ -139,28 +134,12 @@ public final class OutputGenerator {
     // MARK: - Public API (called by OutputNode.append implementations)
 
     @discardableResult public func append(_ node: OutputNode, indentation: Indentation) -> OutputGenerator {
-        if isRecording {
-            recordedFragments.append(.node(node, indentation))
-        } else {
-            // Direct mode (outside generateOutput): process immediately.
-            // This preserves backward compatibility if append is called outside the iterative loop.
-            let fragments = recordNodeFragments(node: node, indentation: indentation)
-            for fragment in fragments {
-                processFragmentDirect(fragment)
-            }
-        }
+        recordedFragments.append(.node(node, indentation))
         return self
     }
 
     @discardableResult public func append(_ node: OutputNode, indentation: Indentation, appendContent: @escaping (OutputGenerator) -> Void) -> OutputGenerator {
-        if isRecording {
-            recordedFragments.append(.nodeCustom(node, indentation, appendContent))
-        } else {
-            let fragments = recordNodeFragments(node: node, indentation: indentation, customAppend: appendContent)
-            for fragment in fragments {
-                processFragmentDirect(fragment)
-            }
-        }
+        recordedFragments.append(.nodeCustom(node, indentation, appendContent))
         return self
     }
 
@@ -172,55 +151,12 @@ public final class OutputGenerator {
     }
 
     @discardableResult public func append(_ string: String) -> OutputGenerator {
-        if isRecording {
-            recordedFragments.append(.text(string))
-        } else {
-            content += string
-        }
+        recordedFragments.append(.text(string))
         return self
     }
 
     @discardableResult public func append(_ convertible: CustomStringConvertible) -> OutputGenerator {
         append(convertible.description)
-    }
-
-    // MARK: - Direct processing fallback
-
-    /// A mapping stack for direct-mode processing (outside generateOutput).
-    private var directMappingStack: [Int] = []
-
-    /// Process a single fragment immediately (used when append is called outside the iterative loop).
-    private func processFragmentDirect(_ fragment: Fragment) {
-        switch fragment {
-        case .text(let str):
-            content += str
-        case .node(let node, let indentation):
-            let fragments = recordNodeFragments(node: node, indentation: indentation)
-            for f in fragments { processFragmentDirect(f) }
-        case .nodeCustom(let node, let indentation, let customAppend):
-            let fragments = recordNodeFragments(node: node, indentation: indentation, customAppend: customAppend)
-            for f in fragments { processFragmentDirect(f) }
-        case .beginNode:
-            directMappingStack.append(content.utf8.count)
-        case .endNode(let node, let indentation):
-            guard let startOffset = directMappingStack.popLast() else { return }
-            let trailingTrivia = node.trailingTrivia(indentation: indentation)
-            var trailingNewline = false
-            if !trailingTrivia.isEmpty && content.last == "\n" {
-                content = String(content.dropLast())
-                trailingNewline = true
-            }
-            let length = content.utf8.count - startOffset
-            if length > 0, let sourceFile = node.sourceFile {
-                mapEntryOffsets.append((sourceFile, node.sourceRange, startOffset, length))
-            }
-            if !trailingTrivia.isEmpty {
-                content += " \(trailingTrivia)"
-                if trailingNewline {
-                    content += "\n"
-                }
-            }
-        }
     }
 
     private func outputMapEntry(for offsets: MapEntryOffsets, in output: Source) -> OutputMap.Entry {

--- a/Sources/SkipSyntax/OutputGenerator.swift
+++ b/Sources/SkipSyntax/OutputGenerator.swift
@@ -3,11 +3,40 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /// Generate output from a graph of nodes.
+///
+/// Uses an iterative approach with an explicit work stack to avoid stack overflow
+/// on deeply nested AST trees (e.g., long SwiftUI modifier chains that produce
+/// hundreds of levels of nesting).
+///
+/// Design: When a node's `append(to:indentation:)` method calls `output.append(child)`,
+/// instead of recursing, the child is recorded as a pending fragment. After the node's
+/// method returns, its recorded fragments are pushed onto the work stack. The main loop
+/// then processes fragments iteratively: text fragments are appended directly to the
+/// output buffer, and node fragments are expanded by running that node's append method
+/// to produce more fragments — all without growing the call stack.
 public final class OutputGenerator {
     private let root: OutputNode
     private var content = ""
     private typealias MapEntryOffsets = (sourceFile: Source.FilePath, sourceRange: Source.Range?, offset: Int, length: Int)
     private var mapEntryOffsets: [MapEntryOffsets] = []
+
+    /// Fragments produced when a node's `append(to:)` runs in recording mode.
+    /// Text fragments are literal string output. Node fragments are deferred child
+    /// expansions. Begin/end markers track source mapping offsets around content.
+    private enum Fragment {
+        case text(String)
+        case node(OutputNode, Indentation)
+        case nodeCustom(OutputNode, Indentation, (OutputGenerator) -> Void)
+        case beginNode(OutputNode)
+        case endNode(OutputNode, Indentation)
+    }
+
+    /// When true, calls to the public `append` methods record fragments
+    /// instead of writing to the output buffer or recursing.
+    private var isRecording = false
+
+    /// Fragments accumulated during the current recording session.
+    private var recordedFragments: [Fragment] = []
 
     /// Supply node.
     init(root: OutputNode) {
@@ -15,7 +44,54 @@ public final class OutputGenerator {
     }
 
     func generateOutput(file: Source.FilePath) -> (output: Source, map: OutputMap) {
-        append(root, indentation: .zero)
+        // Seed the work stack with the root node.
+        var workStack: [Fragment] = [.node(root, .zero)]
+
+        // Stack tracking source-mapping start offsets for nested beginNode/endNode pairs.
+        var mappingStack: [Int] = []
+
+        // Process fragments iteratively until the stack is empty.
+        while let fragment = workStack.popLast() {
+            switch fragment {
+            case .text(let str):
+                content += str
+
+            case .node(let node, let indentation):
+                // Expand this node: run its append(to:) in recording mode to get fragments,
+                // then push them onto the work stack (reversed so first fragment pops first).
+                let fragments = recordNodeFragments(node: node, indentation: indentation)
+                workStack.append(contentsOf: fragments.reversed())
+
+            case .nodeCustom(let node, let indentation, let customAppend):
+                let fragments = recordNodeFragments(node: node, indentation: indentation, customAppend: customAppend)
+                workStack.append(contentsOf: fragments.reversed())
+
+            case .beginNode:
+                // Record the current content offset for source mapping.
+                mappingStack.append(content.utf8.count)
+
+            case .endNode(let node, let indentation):
+                // Compute trailing trivia and source mapping for this node.
+                guard let startOffset = mappingStack.popLast() else { continue }
+                let trailingTrivia = node.trailingTrivia(indentation: indentation)
+                var trailingNewline = false
+                if !trailingTrivia.isEmpty && content.last == "\n" {
+                    content = String(content.dropLast())
+                    trailingNewline = true
+                }
+                let length = content.utf8.count - startOffset
+                if length > 0, let sourceFile = node.sourceFile {
+                    mapEntryOffsets.append((sourceFile, node.sourceRange, startOffset, length))
+                }
+                if !trailingTrivia.isEmpty {
+                    content += " \(trailingTrivia)"
+                    if trailingNewline {
+                        content += "\n"
+                    }
+                }
+            }
+        }
+
         let output = Source(file: file, content: content)
         let ret = (output, OutputMap(entries: mapEntryOffsets.map { outputMapEntry(for: $0, in: output) }))
         content = ""
@@ -23,48 +99,128 @@ public final class OutputGenerator {
         return ret
     }
 
-    @discardableResult public func append(_ node: OutputNode, indentation: Indentation) -> OutputGenerator {
-        return append(node, indentation: indentation) {
-            node.append(to: $0, indentation: indentation)
+    /// Run a node's append method in recording mode to capture its output as fragments.
+    ///
+    /// The node's `append(to:indentation:)` (or custom closure) executes, but every call
+    /// it makes to `output.append(...)` records a fragment rather than recursing or writing.
+    /// The result is a flat list: [leadingTrivia, beginNode, ...childFragments..., endNode].
+    private func recordNodeFragments(node: OutputNode, indentation: Indentation, customAppend: ((OutputGenerator) -> Void)? = nil) -> [Fragment] {
+        // Save and enter recording mode (supports re-entrant recording for the 3-arg form).
+        let savedRecording = isRecording
+        let savedFragments = recordedFragments
+        isRecording = true
+        recordedFragments = []
+
+        // Leading trivia.
+        let leading = node.leadingTrivia(indentation: indentation)
+        if !leading.isEmpty {
+            recordedFragments.append(.text(leading))
         }
+
+        // Source mapping begin marker.
+        recordedFragments.append(.beginNode(node))
+
+        // Run the node's append logic — all its output.append() calls record fragments.
+        if let customAppend = customAppend {
+            customAppend(self)
+        } else {
+            node.append(to: self, indentation: indentation)
+        }
+
+        // Source mapping end marker (handles trailing trivia and offset computation).
+        recordedFragments.append(.endNode(node, indentation))
+
+        let result = recordedFragments
+        isRecording = savedRecording
+        recordedFragments = savedFragments
+        return result
     }
 
-    @discardableResult public func append(_ node: OutputNode, indentation: Indentation, appendContent: (OutputGenerator) -> Void) -> OutputGenerator {
-        append(node.leadingTrivia(indentation: indentation))
-        let startOffset = content.utf8.count
-        appendContent(self)
-        let trailingTrivia = node.trailingTrivia(indentation: indentation)
-        var trailingNewline = false
-        if !trailingTrivia.isEmpty && content.last == "\n" {
-            content = String(content.dropLast())
-            trailingNewline = true
+    // MARK: - Public API (called by OutputNode.append implementations)
+
+    @discardableResult public func append(_ node: OutputNode, indentation: Indentation) -> OutputGenerator {
+        if isRecording {
+            recordedFragments.append(.node(node, indentation))
+        } else {
+            // Direct mode (outside generateOutput): process immediately.
+            // This preserves backward compatibility if append is called outside the iterative loop.
+            let fragments = recordNodeFragments(node: node, indentation: indentation)
+            for fragment in fragments {
+                processFragmentDirect(fragment)
+            }
         }
-        let length = content.utf8.count - startOffset
-        if length > 0, let sourceFile = node.sourceFile {
-            mapEntryOffsets.append((sourceFile, node.sourceRange, startOffset, length))
-        }
-        if !trailingTrivia.isEmpty {
-            content += " \(trailingTrivia)"
-            if trailingNewline {
-                content += "\n"
+        return self
+    }
+
+    @discardableResult public func append(_ node: OutputNode, indentation: Indentation, appendContent: @escaping (OutputGenerator) -> Void) -> OutputGenerator {
+        if isRecording {
+            recordedFragments.append(.nodeCustom(node, indentation, appendContent))
+        } else {
+            let fragments = recordNodeFragments(node: node, indentation: indentation, customAppend: appendContent)
+            for fragment in fragments {
+                processFragmentDirect(fragment)
             }
         }
         return self
     }
 
     @discardableResult public func append(_ nodes: [OutputNode], indentation: Indentation) -> OutputGenerator {
-        nodes.forEach { append($0, indentation: indentation) }
+        for node in nodes {
+            append(node, indentation: indentation)
+        }
         return self
     }
 
     @discardableResult public func append(_ string: String) -> OutputGenerator {
-        content += string
+        if isRecording {
+            recordedFragments.append(.text(string))
+        } else {
+            content += string
+        }
         return self
     }
 
     @discardableResult public func append(_ convertible: CustomStringConvertible) -> OutputGenerator {
         append(convertible.description)
-        return self
+    }
+
+    // MARK: - Direct processing fallback
+
+    /// A mapping stack for direct-mode processing (outside generateOutput).
+    private var directMappingStack: [Int] = []
+
+    /// Process a single fragment immediately (used when append is called outside the iterative loop).
+    private func processFragmentDirect(_ fragment: Fragment) {
+        switch fragment {
+        case .text(let str):
+            content += str
+        case .node(let node, let indentation):
+            let fragments = recordNodeFragments(node: node, indentation: indentation)
+            for f in fragments { processFragmentDirect(f) }
+        case .nodeCustom(let node, let indentation, let customAppend):
+            let fragments = recordNodeFragments(node: node, indentation: indentation, customAppend: customAppend)
+            for f in fragments { processFragmentDirect(f) }
+        case .beginNode:
+            directMappingStack.append(content.utf8.count)
+        case .endNode(let node, let indentation):
+            guard let startOffset = directMappingStack.popLast() else { return }
+            let trailingTrivia = node.trailingTrivia(indentation: indentation)
+            var trailingNewline = false
+            if !trailingTrivia.isEmpty && content.last == "\n" {
+                content = String(content.dropLast())
+                trailingNewline = true
+            }
+            let length = content.utf8.count - startOffset
+            if length > 0, let sourceFile = node.sourceFile {
+                mapEntryOffsets.append((sourceFile, node.sourceRange, startOffset, length))
+            }
+            if !trailingTrivia.isEmpty {
+                content += " \(trailingTrivia)"
+                if trailingNewline {
+                    content += "\n"
+                }
+            }
+        }
     }
 
     private func outputMapEntry(for offsets: MapEntryOffsets, in output: Source) -> OutputMap.Entry {

--- a/Sources/SkipSyntax/OutputGenerator.swift
+++ b/Sources/SkipSyntax/OutputGenerator.swift
@@ -16,7 +16,6 @@
 /// to produce more fragments — all without growing the call stack.
 public final class OutputGenerator {
     private let root: OutputNode
-    private var content = ""
     private typealias MapEntryOffsets = (sourceFile: Source.FilePath, sourceRange: Source.Range?, offset: Int, length: Int)
     private var mapEntryOffsets: [MapEntryOffsets] = []
 
@@ -76,6 +75,8 @@ public final class OutputGenerator {
     }
 
     func generateOutput(file: Source.FilePath) -> (output: Source, map: OutputMap) {
+        var output = ""
+
         // Seed the work stack with the root node.
         var workStack: [Fragment] = [.node(root, .zero)]
 
@@ -86,7 +87,7 @@ public final class OutputGenerator {
         while let fragment = workStack.popLast() {
             switch fragment {
             case .text(let str):
-                content += str
+                output += str
 
             case .node(let node, let indentation):
                 // Expand this node: run its append(to:) in recording mode to get fragments,
@@ -100,33 +101,33 @@ public final class OutputGenerator {
 
             case .beginNode:
                 // Record the current content offset for source mapping.
-                mappingStack.append(content.utf8.count)
+                mappingStack.append(output.utf8.count)
 
             case .endNode(let node, let indentation):
                 // Compute trailing trivia and source mapping for this node.
                 guard let startOffset = mappingStack.popLast() else { continue }
                 let trailingTrivia = node.trailingTrivia(indentation: indentation)
                 var trailingNewline = false
-                if !trailingTrivia.isEmpty && content.last == "\n" {
-                    content = String(content.dropLast())
+                if !trailingTrivia.isEmpty && output.last == "\n" {
+                    output.removeLast()
                     trailingNewline = true
                 }
-                let length = content.utf8.count - startOffset
+                let length = output.utf8.count - startOffset
                 if length > 0, let sourceFile = node.sourceFile {
                     mapEntryOffsets.append((sourceFile, node.sourceRange, startOffset, length))
                 }
                 if !trailingTrivia.isEmpty {
-                    content += " \(trailingTrivia)"
+                    output += " "
+                    output += trailingTrivia
                     if trailingNewline {
-                        content += "\n"
+                        output += "\n"
                     }
                 }
             }
         }
 
-        let output = Source(file: file, content: content)
-        let ret = (output, OutputMap(entries: mapEntryOffsets.map { outputMapEntry(for: $0, in: output) }))
-        content = ""
+        let source = Source(file: file, content: output)
+        let ret = (source, OutputMap(entries: mapEntryOffsets.map { outputMapEntry(for: $0, in: source) }))
         mapEntryOffsets.removeAll()
         return ret
     }


### PR DESCRIPTION
When transpiling very large files, the skipstone process could crash with no useful error message. The only indication would be an unexplained `The file “.Module.sourcehash” couldn’t be opened because there is no such file` error.

The cause could be discerned by looking at crash logs like `~Library/Logs/DiagnosticReports/SkipRunner-2026-04-28-203429.ips`, which might contain:

<details>
<summary>Crash Log</summary>


```json
{"app_name":"SkipRunner","timestamp":"2026-04-28 20:34:29.00 -0400","app_version":"","slice_uuid":"ccecd345-67d4-3dfd-8636-336e059775d5","build_version":"","platform":1,"share_with_app_devs":0,"is_first_party":1,"bug_type":"309","os_version":"macOS 26.4.1 (25E253)","roots_installed":0,"incident_id":"29D6C795-85C1-4E95-945E-D9412642434D","name":"SkipRunner"}
{
  "uptime" : 980000,
  "procRole" : "Unspecified",
  "version" : 2,
  "userID" : 501,
  "deployVersion" : 210,
  "modelCode" : "MacBookPro18,2",
  "coalitionID" : 1116,
  "osVersion" : {
    "train" : "macOS 26.4.1",
    "build" : "25E253",
    "releaseType" : "User"
  },
  "captureTime" : "2026-04-28 20:34:25.4596 -0400",
  "codeSigningMonitor" : 2,
  "incident" : "29D6C795-85C1-4E95-945E-D9412642434D",
  "pid" : 96388,
  "translated" : false,
  "cpuType" : "ARM-64",
  "procLaunch" : "2026-04-28 20:34:21.2245 -0400",
  "procStartAbsTime" : 23521376839812,
  "procExitAbsTime" : 23521478410476,
  "procName" : "SkipRunner",
  "procPath" : "\/opt\/src\/*\/SkipRunner",
  "parentProc" : "SWBBuildService",
  "parentPid" : 96140,
  "coalitionName" : "com.apple.Terminal",
  "crashReporterKey" : "E4C4B189-1382-2C5A-B148-CD6E07701010",
  "appleIntelligenceStatus" : {"state":"unavailable","reasons":["notOptedIn","assetIsNotReady"]},
  "developerMode" : 1,
  "responsiblePid" : 1568,
  "responsibleProc" : "Terminal",
  "codeSigningID" : "SkipRunner-55554944ccecd34567d43dfd8636336e059775d5",
  "codeSigningTeamID" : "",
  "codeSigningFlags" : 570425861,
  "codeSigningValidationCategory" : 10,
  "codeSigningTrustLevel" : 4294967295,
  "codeSigningAuxiliaryInfo" : 0,
  "instructionByteStream" : {"beforePC":"iG8SlOADE6r9e0Gp9E\/CqP8PX9bzAwCqemoSlOADE6r0\/\/8XfyMD1Q==","atPC":"9le9qfRPAan9ewKp\/YMAkfMDAaqoAyuQCAFyOcgBADf1AwOq9AMCqg=="},
  "bootSessionUUID" : "EC1FAC4D-0081-4C2D-946C-C2682CC6D066",
  "wakeTime" : 53099,
  "sleepWakeUUID" : "C049DD23-2066-42F0-A147-02F0411B172D",
  "sip" : "enabled",
  "vmRegionInfo" : "0x16b32fdb0 is in 0x16b32c000-0x16b330000;  bytes after start: 15792  bytes before end: 591\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      Stack                       16b320000-16b32c000    [   48K] rw-\/rwx SM=COW  \n--->  Stack Guard                 16b32c000-16b330000    [   16K] ---\/rwx SM=PRV  \n      Stack                       16b330000-16b3b8000    [  544K] rw-\/rwx SM=PRV  ",
  "exception" : {"codes":"0x0000000000000002, 0x000000016b32fdb0","message":"Could not determine thread index for stack guard region","rawCodes":[2,6093471152],"type":"EXC_BAD_ACCESS","signal":"SIGBUS","subtype":"KERN_PROTECTION_FAILURE at 0x000000016b32fdb0"},
  "termination" : {"flags":0,"code":10,"namespace":"SIGNAL","indicator":"Bus error: 10","byProc":"exc handler","byPid":96388},
  "vmregioninfo" : "0x16b32fdb0 is in 0x16b32c000-0x16b330000;  bytes after start: 15792  bytes before end: 591\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      Stack                       16b320000-16b32c000    [   48K] rw-\/rwx SM=COW  \n--->  Stack Guard                 16b32c000-16b330000    [   16K] ---\/rwx SM=PRV  \n      Stack                       16b330000-16b3b8000    [  544K] rw-\/rwx SM=PRV  ",
  "extMods" : {"caller":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"system":{"thread_create":0,"thread_set_state":5880,"task_for_pid":170},"targeted":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"warnings":0},
  "faultingThread" : 1,
  "threads" : [{"id":30891759,"threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592},{"value":28600187224064},{"value":135985936},{"value":28600187224064},{"value":2},{"value":4294967295},{"value":0},{"value":17179869184},{"value":0},{"value":2},{"value":0},{"value":0},{"value":6659},{"value":0},{"value":18446744073709551569},{"value":12},{"value":0},{"value":4294967295},{"value":2},{"value":28600187224064},{"value":135985936},{"value":28600187224064},{"value":21592279046},{"value":6093403832},{"value":8589934592},{"value":18446744073709550527},{"value":4412409862}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6595913076},"cpsr":{"value":4096},"fp":{"value":6093403680},"sp":{"value":6093403600},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":6595836980},"far":{"value":0}},"queue":"com.apple.main-thread","frames":[{"imageOffset":3124,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":1},{"imageOffset":79220,"symbol":"mach_msg2_internal","symbolLocation":76,"imageIndex":1},{"imageOffset":39360,"symbol":"mach_msg_overwrite","symbolLocation":480,"imageIndex":1},{"imageOffset":4032,"symbol":"mach_msg","symbolLocation":24,"imageIndex":1},{"imageOffset":515432,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":2},{"imageOffset":509524,"symbol":"__CFRunLoopRun","symbolLocation":1188,"imageIndex":2},{"imageOffset":1371104,"symbol":"_CFRunLoopRunSpecificWithOptions","symbolLocation":532,"imageIndex":2},{"imageOffset":992548,"symbol":"CFRunLoopRun","symbolLocation":64,"imageIndex":2},{"imageOffset":396036,"symbol":"CFMainExecutor.run()","symbolLocation":48,"imageIndex":3},{"imageOffset":396552,"symbol":"protocol witness for RunLoopExecutor.run() in conformance DispatchMainExecutor","symbolLocation":40,"imageIndex":3},{"imageOffset":398132,"symbol":"swift_task_asyncMainDrainQueueImpl","symbolLocation":140,"imageIndex":3},{"imageOffset":49880,"symbol":"swift_task_asyncMainDrainQueue","symbolLocation":92,"imageIndex":3},{"imageOffset":7178532,"sourceFile":"SkipRunnerMain.swift","symbol":"SkipRunner_main","symbolLocation":132,"imageIndex":0},{"imageOffset":130468,"symbol":"start","symbolLocation":6992,"imageIndex":4}]},{"frames":[{"imageOffset":15316,"symbol":"swift_beginAccess","symbolLocation":4,"imageIndex":6},{"imageOffset":9005480,"sourceFile":"KotlinExpressionTypes.swift","symbol":"KotlinIdentifier.appendIdentifier(to:indentation:projectedValue:)","symbolLocation":180,"imageIndex":0},{"imageOffset":9014016,"sourceLine":1300,"sourceFile":"KotlinExpressionTypes.swift","symbol":"KotlinIdentifier.append(to:indentation:)","imageIndex":0,"symbolLocation":352},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":8983596,"sourceLine":1117,"sourceFile":"KotlinExpressionTypes.swift","symbol":"KotlinFunctionCall.append(to:indentation:)","imageIndex":0,"symbolLocation":880},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":9088512,"sourceLine":2114,"sourceFile":"KotlinExpressionTypes.swift","symbol":"closure #3 in KotlinMemberAccess.append(to:indentation:)","imageIndex":0,"symbolLocation":212},{"imageOffset":9077420,"sourceLine":2148,"sourceFile":"KotlinExpressionTypes.swift","symbol":"KotlinMemberAccess.appendMemberAccess(to:indentation:projectedValue:appendBase:)","imageIndex":0,"symbolLocation":3292},{"imageOffset":9087772,"sourceLine":2112,"sourceFile":"KotlinExpressionTypes.swift","symbol":"KotlinMemberAccess.append(to:indentation:)","imageIndex":0,"symbolLocation":604},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":9708380,"sourceLine":3185,"sourceFile":"KotlinStatementTypes.swift","symbol":"KotlinVariableDeclaration.appendAsFunctionDefinition(_:to:indentation:)","imageIndex":0,"symbolLocation":1652},{"imageOffset":9693052,"sourceLine":3074,"sourceFile":"KotlinStatementTypes.swift","symbol":"KotlinVariableDeclaration.append(to:indentation:)","imageIndex":0,"symbolLocation":5280},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":9500376,"sourceLine":1308,"sourceFile":"KotlinStatementTypes.swift","symbol":"KotlinClassDeclaration.append(to:indentation:)","imageIndex":0,"symbolLocation":19404},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":10033272,"sourceLine":101,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":1048},{"imageOffset":9401012,"sourceLine":484,"sourceFile":"KotlinStatementTypes.swift","symbol":"KotlinCodeBlock.append(to:indentation:)","imageIndex":0,"symbolLocation":1296},{"imageOffset":9895392,"sourceFile":"\/<compiler-generated>","symbol":"protocol witness for OutputNode.append(to:indentation:) in conformance KotlinSyntaxNode","symbolLocation":28,"imageIndex":0},{"imageOffset":10027992,"sourceLine":51,"sourceFile":"OutputGenerator.swift","symbol":"closure #1 in OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":108},{"imageOffset":10030200,"sourceLine":74,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:appendContent:)","imageIndex":0,"symbolLocation":2180},{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72},{"imageOffset":10023708,"sourceLine":33,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.generateOutput(file:)","imageIndex":0,"symbolLocation":1508},{"imageOffset":9919576,"sourceLine":338,"sourceFile":"KotlinTranslator.swift","symbol":"KotlinTranslator.transpilations(for:codebaseInfo:transformers:input:outputs:startTime:)","imageIndex":0,"symbolLocation":7524},{"imageOffset":9908872,"sourceLine":97,"sourceFile":"KotlinTranslator.swift","symbol":"KotlinTranslator.transpile(codebaseInfo:transformers:startTime:)","imageIndex":0,"symbolLocation":4292},{"imageOffset":10479376,"sourceLine":133,"sourceFile":"Transpiler.swift","symbol":"closure #1 in closure #3 in Transpiler.transpile(handler:)","imageIndex":0,"symbolLocation":1472},{"imageOffset":10485469,"sourceFile":"\/<compiler-generated>","symbol":"partial apply for closure #1 in closure #3 in Transpiler.transpile(handler:)","symbolLocation":1,"imageIndex":0},{"imageOffset":52933,"symbol":"completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*)","symbolLocation":1,"imageIndex":3}],"id":30891765,"recursionInfoArray":[{"hottestElided":19,"coldestElided":501,"depth":91,"keyFrame":{"imageOffset":10027004,"sourceLine":50,"sourceFile":"OutputGenerator.swift","symbol":"OutputGenerator.append(_:indentation:)","imageIndex":0,"symbolLocation":72}}],"originalLength":525,"triggered":true,"threadState":{"x":[{"value":33568092144},{"value":6093474632},{"value":32},{"value":0},{"value":0},{"value":36},{"value":8243110581548379749},{"value":5},{"value":32},{"value":6274202236355477540},{"value":1},{"value":7},{"value":116},{"value":33554458848},{"value":4397386064,"symbolLocation":0,"symbol":"type metadata for KotlinIdentifier"},{"value":2},{"value":6921759696,"symbolLocation":0,"symbol":"swift_beginAccess"},{"value":8589934595},{"value":0},{"value":6093994640},{"value":33568092032},{"value":0},{"value":33534233648},{"value":6},{"value":6094008544},{"value":0},{"value":11306131480,"symbolLocation":0,"symbol":"swift::concurrency::trace::TracingEnabled"},{"value":11306131488,"symbolLocation":0,"symbol":"swift::concurrency::trace::LogsToken"},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":4382435752},"cpsr":{"value":1610616832},"fp":{"value":6093474736},"sp":{"value":6093471200},"esr":{"value":2449473607,"description":"(Data Abort) byte write Translation fault"},"pc":{"value":6921759700,"matchesCrashFrame":1},"far":{"value":6093471152}},"queue":"com.apple.root.default-qos.cooperative"},{"id":30891813,"frames":[],"threadState":{"x":[{"value":6094581760},{"value":5635},{"value":6094045184},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6094581760},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":6596094984},"far":{"value":0}}},{"id":30891823,"frames":[],"threadState":{"x":[{"value":6095155200},{"value":9219},{"value":6094618624},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6095155200},"esr":{"value":1442840704,"description":"(Syscall)"},"pc":{"value":6596094984},"far":{"value":0}}},{"id":30891824,"frames":[],"threadState":{"x":[{"value":6095728640},{"value":0},{"value":6095192064},{"value":0},{"value":278532},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6095728640},"esr":{"value":0},"pc":{"value":6596094984},"far":{"value":0}}}],
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4373430272,
    "size" : 23363584,
    "uuid" : "ccecd345-67d4-3dfd-8636-336e059775d5",
    "path" : "\/opt\/src\/*\/SkipRunner",
    "name" : "SkipRunner"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6595833856,
    "size" : 250512,
    "uuid" : "51565b39-f595-3e96-a217-fef29815057a",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6596374528,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.CoreFoundation",
    "size" : 5626976,
    "uuid" : "04941709-2330-3bf8-9213-6d33964db448",
    "path" : "\/System\/Library\/Frameworks\/CoreFoundation.framework\/Versions\/A\/CoreFoundation",
    "name" : "CoreFoundation",
    "CFBundleVersion" : "4424.1.402"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 10958987264,
    "size" : 569494,
    "uuid" : "02634765-cb69-3c2b-9cce-10103cbea22a",
    "path" : "\/usr\/lib\/swift\/libswift_Concurrency.dylib",
    "name" : "libswift_Concurrency.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6592069632,
    "size" : 679624,
    "uuid" : "9f682dcf-340c-3bfa-bcdd-dd702f30313e",
    "path" : "\/usr\/lib\/dyld",
    "name" : "dyld"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6921744384,
    "size" : 5904704,
    "uuid" : "fb6ad37d-0f92-3774-ab61-0323db22c111",
    "path" : "\/usr\/lib\/swift\/libswiftCore.dylib",
    "name" : "libswiftCore.dylib"
  }
],
  "sharedCache" : {
  "base" : 6590939136,
  "size" : 5978570752,
  "uuid" : "2d40543a-792e-37b8-978d-3d7030e1aa81"
},
  "vmSummary" : "ReadOnly portion of Libraries: Total=909.4M resident=0K(0%) swapped_out_or_unallocated=909.4M(100%)\nWritable regions: Total=168.7M written=433K(0%) resident=433K(0%) swapped_out=0K(0%) unallocated=168.3M(100%)\n\n                                VIRTUAL   REGION \nREGION TYPE                        SIZE    COUNT (non-coalesced) \n===========                     =======  ======= \nActivity Tracing                   256K        1 \nKernel Alloc Once                   32K        1 \nMALLOC                            92.5M       27 \nMALLOC guard page                 3392K        4 \nMemory Tag 22                     64.0M        1 \nMemory Tag 241                     320K        3 \nSTACK GUARD                       56.1M        4 \nStack                             10.1M        6 \nStack Guard                         16K        1 \n__AUTH                            1329K      150 \n__AUTH_CONST                      17.7M      344 \n__CTF                               824        1 \n__DATA                            5636K      301 \n__DATA_CONST                      16.7M      343 \n__DATA_DIRTY                      1334K      287 \n__FONT_DATA                        2352        1 \n__LINKEDIT                       598.1M        2 \n__OBJC_RO                         79.1M        1 \n__OBJC_RW                         2597K        1 \n__TEXT                           311.3M      353 \n__TPRO_CONST                       128K        2 \nmapped file                       47.3M        5 \npage table in kernel               433K        1 \nshared memory                       80K        4 \n===========                     =======  ======= \nTOTAL                              1.3G     1844 \n",
  "legacyInfo" : {
  "threadTriggered" : {
    "queue" : "com.apple.root.default-qos.cooperative"
  }
},
  "logWritingSignature" : "6ee313b021fac0d309297805d70053815e7cb8a6",
  "roots_installed" : 0,
  "bug_type" : "309",
  "trmStatus" : 1,
  "trialInfo" : {
  "rollouts" : [
    {
      "rolloutId" : "682ef9612c2ae30e2f38d3a4",
      "factorPackIds" : [

      ],
      "deploymentId" : 240000006
    },
    {
      "rolloutId" : "645197bf528fbf3c3af54105",
      "factorPackIds" : [
        "663e65b4a1526e1ca0e288a1"
      ],
      "deploymentId" : 240000002
    }
  ],
  "experiments" : [

  ]
}
}
```
</details>

The cause here is a stack overflow when large files are being processed and transpiled. Since transpiling the same files from the command-line seems to work (e.g., with `swift test`), the issue appears to be a limit placed by the plugin sandboxing by Xcode.

To solve this issue, we unwind the recursive output processing and convert it into a flattened iterative process.