### PR TITLE
Add skip meta index command to generate appindex.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,9 @@ jobs:
         run: |
           skip init --transpiled-app --free --appid some.app.id some-app SomeApp SomeAppModel
           # verify that the project itself is free
-          skip verify --sbom --free --project some-app
+          skip verify --free --project some-app
           # perform an export of the app
-          skip export --sbom --show-tree --project some-app
+          skip export --appindex --show-tree --project some-app
 
       # disables to speed up CI
       #- name: "Create and export new Skip Lite app project"

--- a/Sources/SkipBuild/Commands/ExportCommand.swift
+++ b/Sources/SkipBuild/Commands/ExportCommand.swift
@@ -96,6 +96,12 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
     @Flag(help: ArgumentHelp("Generate SPDX SBOM files alongside export artifacts"))
     var sbom: Bool = false
 
+    @Flag(inversion: .prefixedNo, help: ArgumentHelp("Generate appindex.json metadata alongside export artifacts"))
+    var appindex: Bool = false
+
+    @Flag(inversion: .prefixedNo, help: ArgumentHelp("Create a symlink from app Resources to the generated appindex.json"))
+    var linkAppindex: Bool = true
+
     func performCommand(with out: MessageQueue) async {
         await withLogStream(with: out) {
             try await runExport(with: out)
@@ -180,6 +186,16 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
             }
 
             let projectLayout = try AppProjectLayout(moduleName: appModuleName, root: projectURL, check: validateLayoutURL)
+
+            // Generate and link app index before building so it is included in the app bundle
+            if self.appindex {
+                let catalog = try await AppIndexGenerator.generateAppIndex(projectURL: projectURL, packageJSON: packageJSON, includeSBOM: self.sbom, command: self, out: out)
+                try fs.createDirectory(outputFolderAbsolute, recursive: true)
+                let appIndexURL = outputFolderAbsolute.asURL.appendingPathComponent(AppIndexGenerator.appIndexFilename)
+                let indexURL = try await AppIndexGenerator.writeAppIndex(catalog, to: appIndexURL, linkResource: self.linkAppindex, appModuleName: appModuleName, projectURL: projectURL, out: out)
+                createdURLs.append(indexURL)
+                await out.write(status: .pass, "Generated \(AppIndexGenerator.appIndexFilename)")
+            }
 
             // Resolve the scheme name once for all iOS builds
             let appSchemeName = (self.ios || self.iosSim) ? try await resolveAppSchemeName(schemeName: self.schemeName, xcodeProjectURL: projectLayout.darwinProjectFolder, out: out) : nil

--- a/Sources/SkipBuild/Commands/ExportCommand.swift
+++ b/Sources/SkipBuild/Commands/ExportCommand.swift
@@ -93,9 +93,6 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
     @Option(help: ArgumentHelp("Destination architectures for native libraries", valueName: "arch"))
     var arch: [AndroidArchArgument] = []
 
-    @Flag(help: ArgumentHelp("Generate SPDX SBOM files alongside export artifacts"))
-    var sbom: Bool = false
-
     @Flag(inversion: .prefixedNo, help: ArgumentHelp("Generate appindex.json metadata alongside export artifacts"))
     var appindex: Bool = false
 
@@ -189,7 +186,7 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
 
             // Generate and link app index before building so it is included in the app bundle
             if self.appindex {
-                let catalog = try await AppIndexGenerator.generateAppIndex(projectURL: projectURL, packageJSON: packageJSON, includeSBOM: self.sbom, command: self, out: out)
+                let catalog = try await AppIndexGenerator.generateAppIndex(projectURL: projectURL, packageJSON: packageJSON, includeSBOM: true, command: self, out: out)
                 try fs.createDirectory(outputFolderAbsolute, recursive: true)
                 let appIndexURL = outputFolderAbsolute.asURL.appendingPathComponent(AppIndexGenerator.appIndexFilename)
                 let indexURL = try await AppIndexGenerator.writeAppIndex(catalog, to: appIndexURL, linkResource: self.linkAppindex, appModuleName: appModuleName, projectURL: projectURL, out: out)
@@ -335,22 +332,6 @@ Build and export the Skip modules defined in the Package.swift, with libraries e
             createdURLs.append(projectExportZip.asURL)
 
             try fs.removeFileTree(projectOutputBaseFolder) // only export the zip file; remove the sources
-        }
-
-        // Generate SBOM files if requested
-        if self.sbom {
-            let projectURL = URL(fileURLWithPath: self.project).standardized
-            let sbomFiles = try await SBOMGenerator.generateSBOMFiles(
-                generateIOS: self.ios,
-                generateAndroid: self.android,
-                projectPath: projectURL.path,
-                packageName: packageName,
-                packageJSON: packageJSON,
-                outputDirAbsolute: outputFolderAbsolute,
-                command: self,
-                out: out
-            )
-            createdURLs.append(contentsOf: sbomFiles)
         }
 
         let outputFolderTitle = outputFolder.abbreviatingWithTilde

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -1,0 +1,694 @@
+// Copyright (c) 2023 - 2026 Skip
+// Licensed under the GNU Affero General Public License v3.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+import ArgumentParser
+import SkipSyntax
+import TSCBasic
+
+#if canImport(SkipDriveExternal)
+import SkipDriveExternal
+extension MetaIndexCommand : GradleHarness { }
+fileprivate let metaCommandEnabled = true
+#else
+fileprivate let metaCommandEnabled = false
+#endif
+
+// MARK: - Container Command
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+struct MetaCommand: AsyncParsableCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "meta",
+        abstract: "App metadata and SBOM tools",
+        discussion: """
+        Commands for generating app metadata catalogs and Software Bill of Materials (SBOM).
+        """,
+        shouldDisplay: metaCommandEnabled,
+        subcommands: [
+            MetaIndexCommand.self,
+            SBOMCommand.self,
+        ])
+}
+
+// MARK: - Generate Subcommand
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+struct MetaIndexCommand: MessageCommand, ToolOptionsCommand {
+    static var configuration = CommandConfiguration(
+        commandName: "index",
+        abstract: "Generate a JSON metadata index for the app",
+        usage: """
+# generate app metadata to stdout
+skip meta index
+
+# write to a file
+skip meta index -O appindex.json
+
+# include SBOM in the output
+skip meta index --sbom -O appindex.json
+""",
+        discussion: """
+Generate a structured JSON document containing all user-facing metadata for a Skip app, \
+including localized titles and descriptions from fastlane metadata, app permissions \
+from Info.plist and AndroidManifest.xml, version information from Skip.env, \
+and optionally a Software Bill of Materials (SBOM) for each platform.
+
+The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's "zh-Hans").
+""",
+        shouldDisplay: metaCommandEnabled)
+
+    @OptionGroup(title: "Output Options")
+    var outputOptions: OutputOptions
+
+    @OptionGroup(title: "Tool Options")
+    var toolOptions: ToolOptions
+
+    @Option(name: [.customShort("O"), .customLong("catalog-output")], help: ArgumentHelp("Write catalog JSON to the given file instead of stdout", valueName: "path"))
+    var catalogOutput: String?
+
+    @Option(help: ArgumentHelp("Project folder", valueName: "dir"))
+    var project: String = "."
+
+    @Flag(help: ArgumentHelp("Include SBOM in the output"))
+    var sbom: Bool = false
+
+    func performCommand(with out: MessageQueue) async {
+        await withLogStream(with: out) {
+            try await runMetaGenerate(with: out)
+        }
+    }
+
+    func runMetaGenerate(with out: MessageQueue) async throws {
+        let projectURL = URL(fileURLWithPath: self.project).standardized
+        let catalog = try await generateAppCatalog(projectURL: projectURL, includeSBOM: sbom, with: out)
+        let jsonData = try JSONSerialization.data(withJSONObject: catalog, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+
+        if let outputPath = catalogOutput {
+            let outputURL = URL(fileURLWithPath: outputPath)
+            try jsonData.write(to: outputURL)
+            await out.write(status: .pass, "Wrote app catalog to \(outputPath)")
+        } else {
+            // Write to stdout
+            if let jsonString = String(data: jsonData, encoding: .utf8) {
+                print(jsonString)
+            }
+        }
+    }
+
+    // MARK: - Catalog Generation
+
+    func generateAppCatalog(projectURL: URL, includeSBOM: Bool, with out: MessageQueue) async throws -> [String: Any] {
+        let packageJSON = try await parseSwiftPackage(with: out, at: projectURL.path)
+        let moduleNames = packageJSON.targets.compactMap(\.a).filter({ $0.type == "regular" }).filter({ $0.pluginUsages != nil }).map(\.name)
+        guard let appModuleName = moduleNames.first else {
+            throw error("No Skip module targets found in package \(packageJSON.name)")
+        }
+
+        let appProject = AppProjectLayout(moduleName: appModuleName, root: projectURL, check: AppProjectLayout.noURLChecks)
+
+        // Parse Skip.env for shared configuration
+        let env = try parseSkipEnv(at: appProject.skipEnv)
+
+        let bundleId = env["PRODUCT_BUNDLE_IDENTIFIER"] ?? ""
+        let version = env["MARKETING_VERSION"] ?? "0.0.1"
+        let buildNumber = env["CURRENT_PROJECT_VERSION"] ?? "1"
+        let productName = env["PRODUCT_NAME"] ?? appModuleName
+        let androidAppId = env["ANDROID_APPLICATION_ID"]
+        let appleStoreId = env["APPLE_APP_STORE_ID"]
+        let googlePlayStoreId = env["GOOGLE_PLAY_STORE_ID"]
+
+        // Build per-platform metadata
+        var iosDict = try buildIOSMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, version: version, buildNumber: buildNumber, appleStoreId: appleStoreId)
+        var androidDict = try buildAndroidMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, androidAppId: androidAppId, version: version, buildNumber: buildNumber, googlePlayStoreId: googlePlayStoreId)
+
+        // Include SBOM if requested
+        if includeSBOM {
+            #if canImport(SkipDriveExternal)
+            let outputDir = try AbsolutePath(validating: NSTemporaryDirectory())
+            let sbomFiles = try await SBOMGenerator.generateSBOMFiles(generateIOS: true, generateAndroid: true, projectPath: projectURL.path, packageName: packageJSON.name, packageJSON: packageJSON, outputDirAbsolute: outputDir, command: self, out: out)
+            for file in sbomFiles {
+                let data = try Data(contentsOf: file)
+                let json = try JSONSerialization.jsonObject(with: data)
+                if file.lastPathComponent.contains("darwin") || file.lastPathComponent.contains("ios") {
+                    iosDict["sbom"] = json
+                } else if file.lastPathComponent.contains("android") {
+                    androidDict["sbom"] = json
+                }
+            }
+            #endif
+        }
+
+        let appDict: [String: Any] = [
+            "name": productName,
+            "version": version,
+            "buildNumber": buildNumber,
+            "platforms": [
+                "ios": iosDict,
+                "android": androidDict,
+            ] as [String: Any],
+        ]
+
+        return ["app": appDict]
+    }
+
+    // MARK: - Skip.env Parsing
+
+    func parseSkipEnv(at url: URL) throws -> [String: String] {
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        var env: [String: String] = [:]
+        for (key, value) in parseXCConfig(contents: contents) {
+            env[key] = value
+        }
+        return env
+    }
+
+    // MARK: - iOS Metadata
+
+    func buildIOSMetadata(appProject: AppProjectLayout, projectRoot: URL, productName: String, bundleId: String, version: String, buildNumber: String, appleStoreId: String?) throws -> [String: Any] {
+        var ios: [String: Any] = [
+            "platform": "ios",
+            "bundleIdentifier": bundleId,
+            "version": version,
+            "buildNumber": buildNumber,
+        ]
+
+        if let appleStoreId = appleStoreId, !appleStoreId.isEmpty {
+            ios["appStoreId"] = appleStoreId
+            ios["appStoreURL"] = "https://apps.apple.com/app/id\(appleStoreId)"
+        }
+
+        // Parse Info.plist for permissions and metadata (optional file)
+        if FileManager.default.fileExists(atPath: appProject.darwinInfoPlist.path) {
+            let infoPlistData = try parseInfoPlist(at: appProject.darwinInfoPlist)
+            if !infoPlistData.isEmpty {
+                ios["infoPlist"] = infoPlistData
+            }
+            let permissions = try extractIOSPermissions(at: appProject.darwinInfoPlist)
+            if !permissions.isEmpty {
+                ios["permissions"] = permissions
+            }
+        }
+
+        // Parse Entitlements.plist
+        if FileManager.default.fileExists(atPath: appProject.darwinEntitlementsPlist.path) {
+            let entitlements = try parseEntitlements(at: appProject.darwinEntitlementsPlist)
+            if !entitlements.isEmpty {
+                ios["entitlements"] = entitlements
+            }
+        }
+
+        // Parse localized fastlane metadata
+        let localizedMeta = parseFastlaneMetadata(folder: appProject.darwinFastlaneMetadataFolder, platform: .ios)
+        for (key, locales) in localizedMeta {
+            ios[key] = locales
+        }
+
+        // App icon: largest PNG in AppIcon.appiconset
+        if let iconRef = findLargestPNG(in: appProject.darwinAppIconFolder, relativeTo: projectRoot) {
+            ios["icon"] = iconRef.asDictionary
+        }
+
+        // Screenshots: Darwin/fastlane/screenshots/{locale}/*.png
+        let screenshotDir = appProject.darwinFastlaneFolder.appendingPathComponent("screenshots")
+        let screenshots = collectLocalizedScreenshots(folder: screenshotDir, relativeTo: projectRoot)
+        if !screenshots.isEmpty {
+            ios["screenshots"] = screenshots
+        }
+
+        return ios
+    }
+
+    // MARK: - Android Metadata
+
+    func buildAndroidMetadata(appProject: AppProjectLayout, projectRoot: URL, productName: String, bundleId: String, androidAppId: String?, version: String, buildNumber: String, googlePlayStoreId: String?) throws -> [String: Any] {
+        let effectiveAppId = androidAppId ?? bundleId.replacingOccurrences(of: "-", with: "_")
+
+        var android: [String: Any] = [
+            "platform": "android",
+            "applicationId": effectiveAppId,
+            "version": version,
+            "buildNumber": buildNumber,
+        ]
+
+        if let googlePlayStoreId = googlePlayStoreId, !googlePlayStoreId.isEmpty {
+            android["playStoreId"] = googlePlayStoreId
+            android["playStoreURL"] = "https://play.google.com/store/apps/details?id=\(googlePlayStoreId)"
+        } else {
+            android["playStoreURL"] = "https://play.google.com/store/apps/details?id=\(effectiveAppId)"
+        }
+
+        // Parse AndroidManifest.xml for permissions and metadata
+        if FileManager.default.fileExists(atPath: appProject.androidManifest.path) {
+            let manifestPermissions = try extractAndroidPermissions(at: appProject.androidManifest)
+            if !manifestPermissions.isEmpty {
+                android["permissions"] = manifestPermissions
+            }
+            let manifestMeta = try parseAndroidManifest(at: appProject.androidManifest)
+            if !manifestMeta.isEmpty {
+                android["manifest"] = manifestMeta
+            }
+        }
+
+        // Parse localized fastlane metadata
+        let localizedMeta = parseFastlaneMetadata(folder: appProject.androidFastlaneMetadataFolder, platform: .android)
+        for (key, locales) in localizedMeta {
+            android[key] = locales
+        }
+
+        // App icon: Android/fastlane/metadata/android/en-US/images/icon.png
+        let androidIconURL = appProject.androidFastlaneMetadataFolder.appendingPathComponent("en-US/images/icon.png")
+        if let iconRef = ImageResourceRef.from(pngURL: androidIconURL, relativeTo: projectRoot) {
+            android["icon"] = iconRef.asDictionary
+        }
+
+        // Feature graphic: Android/fastlane/metadata/android/{locale}/images/featureGraphic.png
+        let featureGraphics = collectLocalizedImages(named: "featureGraphic.png", subpath: "images", metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot)
+        if !featureGraphics.isEmpty {
+            android["featureGraphic"] = featureGraphics
+        }
+
+        // Screenshots: Android/fastlane/metadata/android/{locale}/images/phoneScreenshots/
+        let screenshots = collectAndroidScreenshots(metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot)
+        if !screenshots.isEmpty {
+            android["screenshots"] = screenshots
+        }
+
+        return android
+    }
+
+    // MARK: - Info.plist Parsing
+
+    func parseInfoPlist(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            throw error("Info.plist at \(url.path) is not a valid dictionary plist")
+        }
+        var result: [String: Any] = [:]
+        let includeKeys = ["CFBundleName", "CFBundleDisplayName", "CFBundleShortVersionString", "CFBundleVersion",
+                           "ITSAppUsesNonExemptEncryption", "UIRequiredDeviceCapabilities",
+                           "UISupportedInterfaceOrientations", "UILaunchStoryboardName",
+                           "LSApplicationQueriesSchemes", "CFBundleURLTypes"]
+        for key in includeKeys {
+            if let value = plist[key] {
+                result[key] = value
+            }
+        }
+        return result
+    }
+
+    func extractIOSPermissions(at url: URL) throws -> [[String: String]] {
+        let data = try Data(contentsOf: url)
+        guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            throw error("Info.plist at \(url.path) is not a valid dictionary plist")
+        }
+        var permissions: [[String: String]] = []
+        for (key, value) in plist {
+            if key.hasSuffix("UsageDescription"), let desc = value as? String {
+                permissions.append(["key": key, "description": desc])
+            }
+        }
+        return permissions.sorted { ($0["key"] ?? "") < ($1["key"] ?? "") }
+    }
+
+    // MARK: - Entitlements Parsing
+
+    func parseEntitlements(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
+            throw error("Entitlements.plist at \(url.path) is not a valid dictionary plist")
+        }
+        return plist
+    }
+
+    // MARK: - AndroidManifest.xml Parsing
+
+    func parseAndroidManifest(at url: URL) throws -> [String: Any] {
+        let data = try Data(contentsOf: url)
+        let delegate = AndroidManifestParserDelegate()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        guard parser.parse() else {
+            let parseError = parser.parserError.map { ": \($0.localizedDescription)" } ?? ""
+            throw error("Failed to parse AndroidManifest.xml at \(url.path)\(parseError)")
+        }
+        return delegate.metadata
+    }
+
+    func extractAndroidPermissions(at url: URL) throws -> [[String: String]] {
+        let data = try Data(contentsOf: url)
+        let delegate = AndroidManifestParserDelegate()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        guard parser.parse() else {
+            let parseError = parser.parserError.map { ": \($0.localizedDescription)" } ?? ""
+            throw error("Failed to parse AndroidManifest.xml at \(url.path)\(parseError)")
+        }
+        return delegate.permissions
+    }
+
+    // MARK: - Fastlane Metadata Parsing
+
+    enum MetadataPlatform {
+        case ios
+        case android
+    }
+
+    /// Metadata files we extract from fastlane directories.
+    /// iOS: Darwin/fastlane/metadata/{locale}/{file}.txt
+    /// Android: Android/fastlane/metadata/android/{locale}/{file}.txt
+    static let iosMetadataFiles = ["title", "subtitle", "description", "keywords", "release_notes",
+                                   "privacy_url", "support_url", "marketing_url"]
+    static let androidMetadataFiles = ["title", "short_description", "full_description"]
+
+    func parseFastlaneMetadata(folder: URL, platform: MetadataPlatform) -> [String: [String: String]] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: folder.path) else { return [:] }
+        guard let locales = try? fm.contentsOfDirectory(atPath: folder.path) else { return [:] }
+
+        let metadataFiles = platform == .ios ? Self.iosMetadataFiles : Self.androidMetadataFiles
+        var result: [String: [String: String]] = [:]
+
+        for locale in locales.sorted() {
+            let localeDir = folder.appendingPathComponent(locale)
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: localeDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
+
+            let normalizedLocale = Self.normalizeLocale(locale)
+
+            for fileName in metadataFiles {
+                let filePath = localeDir.appendingPathComponent(fileName + ".txt")
+                guard fm.fileExists(atPath: filePath.path) else { continue }
+                guard let content = try? String(contentsOf: filePath, encoding: .utf8).trimmingCharacters(in: .whitespacesAndNewlines),
+                      !content.isEmpty else { continue }
+
+                let key = Self.normalizeMetadataKey(fileName, platform: platform)
+                if result[key] == nil {
+                    result[key] = [:]
+                }
+                result[key]?[normalizedLocale] = content
+            }
+        }
+
+        return result
+    }
+
+    /// Normalize a metadata file name to a common key across platforms.
+    static func normalizeMetadataKey(_ fileName: String, platform: MetadataPlatform) -> String {
+        switch fileName {
+        case "full_description": return "description"
+        case "short_description": return "subtitle"
+        case "release_notes", "version_whats_new": return "releaseNotes"
+        case "privacy_url": return "privacyURL"
+        case "support_url": return "supportURL"
+        case "marketing_url": return "marketingURL"
+        default: return fileName
+        }
+    }
+
+    // MARK: - Locale Normalization
+
+    /// Normalize Apple/iOS locale codes to Android/Play Store codes.
+    /// Apple uses codes like "zh-Hans", "zh-Hant", "pt-BR", "ar-SA".
+    /// Android uses codes like "zh-CN", "zh-TW", "pt-BR", "ar".
+    /// See: https://support.google.com/googleplay/android-developer/answer/9844778
+    static func normalizeLocale(_ locale: String) -> String {
+        // Apple script subtag → Android region subtag mappings
+        let scriptMappings: [String: String] = [
+            "zh-Hans": "zh-CN",
+            "zh-Hant": "zh-TW",
+            "zh-Hant-TW": "zh-TW",
+            "zh-Hant-HK": "zh-HK",
+        ]
+
+        if let mapped = scriptMappings[locale] {
+            return mapped
+        }
+
+        // Apple sometimes uses 3-letter region subtags that Android doesn't use
+        let simplifyMappings: [String: String] = [
+            "ar-SA": "ar",
+            "ca-ES": "ca",
+            "cs-CZ": "cs",
+            "da-DK": "da",
+            "el-GR": "el",
+            "fi-FI": "fi",
+            "he-IL": "iw-IL",  // Android uses "iw" for Hebrew
+            "hi-IN": "hi-IN",
+            "hr-HR": "hr",
+            "hu-HU": "hu",
+            "id-ID": "id",
+            "ja-JP": "ja-JP",
+            "ko-KR": "ko-KR",
+            "ms-MY": "ms-MY",
+            "nb-NO": "no-NO",  // Norwegian Bokmal → "no" on Android
+            "nl-NL": "nl-NL",
+            "pl-PL": "pl-PL",
+            "pt-PT": "pt-PT",
+            "ro-RO": "ro",
+            "ru-RU": "ru-RU",
+            "sk-SK": "sk",
+            "sv-SE": "sv-SE",
+            "th-TH": "th",
+            "tr-TR": "tr-TR",
+            "uk-UA": "uk",
+            "vi-VN": "vi",
+        ]
+
+        if let mapped = simplifyMappings[locale] {
+            return mapped
+        }
+
+        return locale
+    }
+}
+
+// MARK: - Image Resource Reference
+
+public struct ImageResourceRef: Codable, Equatable, Sendable {
+    public var mimeType: String?
+    public var location: String
+    public var size: Int64
+    public var hash: String
+    public var width: Int
+    public var height: Int
+    public var caption: String?
+
+    /// Convert to a dictionary for JSON serialization.
+    var asDictionary: [String: Any] {
+        var dict: [String: Any] = [
+            "location": location,
+            "size": size,
+            "hash": hash,
+            "width": width,
+            "height": height,
+        ]
+        if let mimeType = mimeType { dict["mimeType"] = mimeType }
+        if let caption = caption { dict["caption"] = caption }
+        return dict
+    }
+
+    /// Create an ImageResourceRef from a PNG file URL, relative to the project root.
+    static func from(pngURL: URL, relativeTo root: URL) -> ImageResourceRef? {
+        guard let data = try? Data(contentsOf: pngURL) else { return nil }
+        let fileSize = Int64(data.count)
+        guard fileSize > 0 else { return nil }
+        let hash = data.SHA256Hash()
+        let (width, height) = parsePNGDimensions(data)
+        let location = relativePath(of: pngURL, to: root)
+        return ImageResourceRef(mimeType: "image/png", location: location, size: fileSize, hash: hash, width: width, height: height)
+    }
+
+    /// Parse width and height from a PNG file's IHDR chunk.
+    /// PNG format: 8-byte signature, then IHDR chunk with 4-byte length, 4-byte type ("IHDR"),
+    /// 4-byte width (big-endian), 4-byte height (big-endian).
+    static func parsePNGDimensions(_ data: Data) -> (width: Int, height: Int) {
+        // PNG signature is 8 bytes, then first chunk: 4 bytes length + 4 bytes "IHDR" + 4 bytes width + 4 bytes height
+        // Minimum offset for width: 16, for height: 20
+        guard data.count >= 24 else { return (0, 0) }
+        // Verify PNG signature
+        let sig: [UInt8] = [137, 80, 78, 71, 13, 10, 26, 10]
+        for i in 0..<8 {
+            if data[i] != sig[i] { return (0, 0) }
+        }
+        // Width at offset 16, height at offset 20 (big-endian UInt32)
+        let width = Int(data[16]) << 24 | Int(data[17]) << 16 | Int(data[18]) << 8 | Int(data[19])
+        let height = Int(data[20]) << 24 | Int(data[21]) << 16 | Int(data[22]) << 8 | Int(data[23])
+        return (width, height)
+    }
+
+    /// Compute a relative path from a file URL to a root URL.
+    static func relativePath(of fileURL: URL, to root: URL) -> String {
+        let filePath = fileURL.standardized.path
+        let rootPath = root.standardized.path.hasSuffix("/") ? root.standardized.path : root.standardized.path + "/"
+        if filePath.hasPrefix(rootPath) {
+            return String(filePath.dropFirst(rootPath.count))
+        }
+        return filePath
+    }
+}
+
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+extension MetaIndexCommand {
+
+    // MARK: - Icon Discovery
+
+    /// Find the largest PNG file in a directory (used for iOS AppIcon.appiconset).
+    func findLargestPNG(in folder: URL, relativeTo root: URL) -> ImageResourceRef? {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: folder.path) else { return nil }
+        guard let files = try? fm.contentsOfDirectory(atPath: folder.path) else { return nil }
+
+        var largest: (url: URL, size: Int64)? = nil
+        for file in files where file.hasSuffix(".png") {
+            let fileURL = folder.appendingPathComponent(file)
+            guard let attrs = try? fm.attributesOfItem(atPath: fileURL.path),
+                  let fileSize = attrs[.size] as? Int64 else { continue }
+            if largest == nil || fileSize > largest!.size {
+                largest = (fileURL, fileSize)
+            }
+        }
+
+        guard let best = largest else { return nil }
+        return ImageResourceRef.from(pngURL: best.url, relativeTo: root)
+    }
+
+    // MARK: - Localized Image Discovery
+
+    /// Collect a single named image file across locale directories.
+    /// Returns a locale → ImageResourceRef dictionary.
+    /// Path: {metadataFolder}/{locale}/{subpath}/{fileName}
+    func collectLocalizedImages(named fileName: String, subpath: String, metadataFolder: URL, relativeTo root: URL) -> [String: [String: Any]] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: metadataFolder.path) else { return [:] }
+        guard let locales = try? fm.contentsOfDirectory(atPath: metadataFolder.path) else { return [:] }
+
+        var result: [String: [String: Any]] = [:]
+        for locale in locales.sorted() {
+            let imageURL = metadataFolder.appendingPathComponent(locale)
+                .appendingPathComponent(subpath)
+                .appendingPathComponent(fileName)
+            if fm.fileExists(atPath: imageURL.path),
+               let ref = ImageResourceRef.from(pngURL: imageURL, relativeTo: root) {
+                result[Self.normalizeLocale(locale)] = ref.asDictionary
+            }
+        }
+        return result
+    }
+
+    // MARK: - Screenshot Discovery
+
+    /// Collect iOS screenshots from Darwin/fastlane/screenshots/{locale}/*.png
+    func collectLocalizedScreenshots(folder: URL, relativeTo root: URL) -> [String: [[String: Any]]] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: folder.path) else { return [:] }
+        guard let locales = try? fm.contentsOfDirectory(atPath: folder.path) else { return [:] }
+
+        var result: [String: [[String: Any]]] = [:]
+
+        for locale in locales.sorted() {
+            let localeDir = folder.appendingPathComponent(locale)
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: localeDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
+
+            let normalizedLocale = Self.normalizeLocale(locale)
+            var refs: [[String: Any]] = []
+
+            if let files = try? fm.contentsOfDirectory(atPath: localeDir.path) {
+                for file in files.sorted() where file.hasSuffix(".png") {
+                    let fileURL = localeDir.appendingPathComponent(file)
+                    if let ref = ImageResourceRef.from(pngURL: fileURL, relativeTo: root) {
+                        refs.append(ref.asDictionary)
+                    }
+                }
+            }
+
+            if !refs.isEmpty {
+                result[normalizedLocale] = refs
+            }
+        }
+
+        return result
+    }
+
+    /// Collect Android screenshots from Android/fastlane/metadata/android/{locale}/images/phoneScreenshots/*.png
+    func collectAndroidScreenshots(metadataFolder: URL, relativeTo root: URL) -> [String: [[String: Any]]] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: metadataFolder.path) else { return [:] }
+        guard let locales = try? fm.contentsOfDirectory(atPath: metadataFolder.path) else { return [:] }
+
+        var result: [String: [[String: Any]]] = [:]
+
+        for locale in locales.sorted() {
+            let screenshotDir = metadataFolder.appendingPathComponent(locale)
+                .appendingPathComponent("images/phoneScreenshots")
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: screenshotDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
+
+            let normalizedLocale = Self.normalizeLocale(locale)
+            var refs: [[String: Any]] = []
+
+            if let files = try? fm.contentsOfDirectory(atPath: screenshotDir.path) {
+                for file in files.sorted() where file.hasSuffix(".png") {
+                    let fileURL = screenshotDir.appendingPathComponent(file)
+                    if let ref = ImageResourceRef.from(pngURL: fileURL, relativeTo: root) {
+                        refs.append(ref.asDictionary)
+                    }
+                }
+            }
+
+            if !refs.isEmpty {
+                result[normalizedLocale] = refs
+            }
+        }
+
+        return result
+    }
+}
+
+// MARK: - Android Manifest XML Parser
+
+/// XMLParser delegate that extracts metadata and permissions from AndroidManifest.xml.
+private class AndroidManifestParserDelegate: NSObject, XMLParserDelegate {
+    var metadata: [String: Any] = [:]
+    var permissions: [[String: String]] = []
+
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String] = [:]) {
+        switch elementName {
+        case "manifest":
+            if let pkg = attributeDict["package"] {
+                metadata["package"] = pkg
+            }
+        case "application":
+            if let label = attributeDict["android:label"] {
+                metadata["label"] = label
+            }
+            if let name = attributeDict["android:name"] {
+                metadata["name"] = name
+            }
+            if let icon = attributeDict["android:icon"] {
+                metadata["icon"] = icon
+            }
+            if let theme = attributeDict["android:theme"] {
+                metadata["theme"] = theme
+            }
+        case "uses-permission":
+            if let name = attributeDict["android:name"] {
+                permissions.append(["name": name])
+            }
+        case "uses-feature":
+            if let name = attributeDict["android:name"] {
+                var feature: [String: String] = ["name": name]
+                if let required = attributeDict["android:required"] {
+                    feature["required"] = required
+                }
+                var features = metadata["features"] as? [[String: String]] ?? []
+                features.append(feature)
+                metadata["features"] = features
+            }
+        default:
+            break
+        }
+    }
+}

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -108,6 +108,50 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
         return try await AppIndexGenerator.generateAppIndex(projectURL: projectURL, packageJSON: packageJSON, includeSBOM: includeSBOM, command: self, out: out)
     }
 
+    // MARK: - Git Origin Parsing
+
+    /// Parse the git remote origin URL from `.git/config`.
+    func parseGitOriginURL(projectRoot: URL) -> String? {
+        let gitConfig = projectRoot.appendingPathComponent(".git/config")
+        guard let contents = try? String(contentsOf: gitConfig, encoding: .utf8) else { return nil }
+
+        var inOrigin = false
+        for line in contents.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("[") {
+                inOrigin = trimmed == "[remote \"origin\"]"
+                continue
+            }
+            if inOrigin && trimmed.hasPrefix("url") {
+                let parts = trimmed.split(separator: "=", maxSplits: 1)
+                if parts.count == 2 {
+                    return parts[1].trimmingCharacters(in: .whitespaces)
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Convert a git remote URL to an HTTPS browse URL.
+    /// Handles both HTTPS and SSH formats:
+    ///   https://github.com/Org/Repo.git → https://github.com/Org/Repo
+    ///   git@github.com:Org/Repo.git     → https://github.com/Org/Repo
+    static func gitRemoteToHTTPS(_ remoteURL: String) -> String {
+        var url = remoteURL
+        // Convert SSH to HTTPS
+        if url.hasPrefix("git@") {
+            url = url.replacingOccurrences(of: "git@", with: "https://")
+            if let colonRange = url.range(of: ":", range: url.index(url.startIndex, offsetBy: 8)..<url.endIndex) {
+                url = url.replacingCharacters(in: colonRange, with: "/")
+            }
+        }
+        // Strip trailing .git
+        if url.hasSuffix(".git") {
+            url = String(url.dropLast(4))
+        }
+        return url
+    }
+
     // MARK: - Skip.env Parsing
 
     func parseSkipEnv(at url: URL) throws -> [String: String] {
@@ -140,7 +184,8 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
             if !infoPlistData.isEmpty {
                 ios["infoPlist"] = infoPlistData
             }
-            let permissions = try extractIOSPermissions(at: appProject.darwinInfoPlist)
+            let xcstringsURL = FileManager.default.fileExists(atPath: appProject.darwinInfoPlistXcstrings.path) ? appProject.darwinInfoPlistXcstrings : nil
+            let permissions = try extractIOSPermissions(at: appProject.darwinInfoPlist, xcstringsURL: xcstringsURL)
             if !permissions.isEmpty {
                 ios["permissions"] = permissions
             }
@@ -253,18 +298,65 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
         return result
     }
 
-    func extractIOSPermissions(at url: URL) throws -> [[String: String]] {
-        let data = try Data(contentsOf: url)
+    func extractIOSPermissions(at plistURL: URL, xcstringsURL: URL?, defaultLocale: String = "en-US") throws -> [[String: Any]] {
+        let data = try Data(contentsOf: plistURL)
         guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
-            throw error("Info.plist at \(url.path) is not a valid dictionary plist")
+            throw error("Info.plist at \(plistURL.path) is not a valid dictionary plist")
         }
-        var permissions: [[String: String]] = []
+
+        // Parse InfoPlist.xcstrings for translations if available
+        let xcstringsTranslations = xcstringsURL.flatMap { parseXcstrings(at: $0) } ?? [:]
+
+        var permissions: [[String: Any]] = []
         for (key, value) in plist {
-            if key.hasSuffix("UsageDescription"), let desc = value as? String {
-                permissions.append(["key": key, "description": desc])
+            guard key.hasSuffix("UsageDescription"), let defaultDesc = value as? String else { continue }
+
+            var descriptions: [String: String] = [defaultLocale: defaultDesc]
+
+            // Merge translations from xcstrings
+            if let localizations = xcstringsTranslations[key] {
+                for (locale, translation) in localizations {
+                    let normalizedLocale = Self.normalizeLocale(locale)
+                    descriptions[normalizedLocale] = translation
+                }
+            }
+
+            permissions.append([
+                "key": key,
+                "description": descriptions,
+            ] as [String: Any])
+        }
+
+        return permissions.sorted { ($0["key"] as? String ?? "") < ($1["key"] as? String ?? "") }
+    }
+
+    // MARK: - Xcstrings Parsing
+
+    /// Parse an .xcstrings file and return a map of key → { locale → translated string }.
+    func parseXcstrings(at url: URL) -> [String: [String: String]]? {
+        guard let data = try? Data(contentsOf: url),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let strings = json["strings"] as? [String: Any] else {
+            return nil
+        }
+
+        var result: [String: [String: String]] = [:]
+        for (key, value) in strings {
+            guard let entry = value as? [String: Any],
+                  let localizations = entry["localizations"] as? [String: Any] else { continue }
+            var translations: [String: String] = [:]
+            for (locale, locValue) in localizations {
+                if let locDict = locValue as? [String: Any],
+                   let stringUnit = locDict["stringUnit"] as? [String: Any],
+                   let translated = stringUnit["value"] as? String {
+                    translations[locale] = translated
+                }
+            }
+            if !translations.isEmpty {
+                result[key] = translations
             }
         }
-        return permissions.sorted { ($0["key"] ?? "") < ($1["key"] ?? "") }
+        return result
     }
 
     // MARK: - Entitlements Parsing
@@ -640,7 +732,7 @@ enum AppIndexGenerator {
             #endif
         }
 
-        let appDict: [String: Any] = [
+        var appDict: [String: Any] = [
             "name": productName,
             "version": version,
             "buildNumber": buildNumber,
@@ -649,6 +741,19 @@ enum AppIndexGenerator {
                 "android": androidDict,
             ] as [String: Any],
         ]
+
+        // Add source repository info from .git/config
+        if let originURL = cmd.parseGitOriginURL(projectRoot: projectURL) {
+            let browseURL = MetaIndexCommand.gitRemoteToHTTPS(originURL)
+            var source: [String: String] = [
+                "url": originURL,
+            ]
+            if browseURL.contains("github.com") {
+                source["release"] = "\(browseURL)/releases/tag/\(version)/"
+                source["assets"] = "https://raw.githubusercontent.com/\(browseURL.components(separatedBy: "github.com/").last ?? "")/refs/tags/\(version)/"
+            }
+            appDict["source"] = source
+        }
 
         return ["app": appDict]
     }
@@ -708,7 +813,7 @@ private class AndroidManifestParserDelegate: NSObject, XMLParserDelegate {
             }
         case "uses-permission":
             if let name = attributeDict["android:name"] {
-                permissions.append(["name": name])
+                permissions.append(["key": name])
             }
         case "uses-feature":
             if let name = attributeDict["android:name"] {

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -7,6 +7,10 @@ import ArgumentParser
 import SkipSyntax
 import TSCBasic
 
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
 #if canImport(SkipDriveExternal)
 import SkipDriveExternal
 extension MetaIndexCommand : GradleHarness { }

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -152,6 +152,60 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
         return url
     }
 
+    // MARK: - License Detection
+
+    /// Detect the SPDX license identifier from a LICENSE file in the project root.
+    func detectLicense(projectRoot: URL) -> String? {
+        let fm = FileManager.default
+        let candidates = ["LICENSE", "LICENSE.md", "LICENSE.txt", "LICENSE.GPL", "LICENSE.AGPL", "LICENSE.MPL", "LICENCE", "LICENCE.md", "LICENCE.txt", "LICENSE-MIT", "LICENSE-APACHE", "COPYING", "COPYING.md"]
+        for name in candidates {
+            let url = projectRoot.appendingPathComponent(name)
+            guard fm.fileExists(atPath: url.path),
+                  let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let lower = content.lowercased()
+            // Check for common SPDX-identifiable licenses by their distinctive text
+            if lower.contains("gnu general public license") && lower.contains("version 3") {
+                return lower.contains("affero") ? "AGPL-3.0-only" : "GPL-3.0-only"
+            }
+            if lower.contains("gnu general public license") && lower.contains("version 2") {
+                return "GPL-2.0-only"
+            }
+            if lower.contains("gnu lesser general public license") {
+                return lower.contains("version 3") ? "LGPL-3.0-only" : "LGPL-2.1-only"
+            }
+            if lower.contains("mozilla public license") && lower.contains("version 2") {
+                return "MPL-2.0"
+            }
+            if lower.contains("apache license") && lower.contains("version 2") {
+                return "Apache-2.0"
+            }
+            if lower.contains("mit license") || lower.contains("permission is hereby granted, free of charge") {
+                return "MIT"
+            }
+            if lower.contains("bsd 2-clause") || (lower.contains("redistribution and use") && !lower.contains("neither the name")) {
+                return "BSD-2-Clause"
+            }
+            if lower.contains("bsd 3-clause") || (lower.contains("redistribution and use") && lower.contains("neither the name")) {
+                return "BSD-3-Clause"
+            }
+            if lower.contains("the unlicense") || lower.contains("this is free and unencumbered software") {
+                return "Unlicense"
+            }
+            if lower.contains("isc license") {
+                return "ISC"
+            }
+            // Check for SPDX header in the file itself
+            if let range = content.range(of: "SPDX-License-Identifier:") {
+                let start = range.upperBound
+                let remaining = content[start...].trimmingCharacters(in: .whitespaces)
+                let id = remaining.components(separatedBy: .whitespacesAndNewlines).first ?? ""
+                if !id.isEmpty { return id }
+            }
+            return nil
+        }
+        return nil
+    }
+
     // MARK: - Skip.env Parsing
 
     func parseSkipEnv(at url: URL) throws -> [String: String] {
@@ -167,22 +221,26 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
 
     func buildIOSMetadata(appProject: AppProjectLayout, projectRoot: URL, productName: String, bundleId: String, version: String, buildNumber: String, appleStoreId: String?) throws -> [String: Any] {
         var ios: [String: Any] = [
-            "platform": "ios",
             "bundleIdentifier": bundleId,
             "version": version,
             "buildNumber": buildNumber,
         ]
 
         if let appleStoreId = appleStoreId, !appleStoreId.isEmpty {
-            ios["appStoreId"] = appleStoreId
-            ios["appStoreURL"] = "https://apps.apple.com/app/id\(appleStoreId)"
+            ios["channels"] = [
+                "appleappstore": [
+                    "id": appleStoreId,
+                    "url": "https://apps.apple.com/app/id\(appleStoreId)",
+                ] as [String: Any]
+            ] as [String: Any]
         }
 
-        // Parse Info.plist for permissions and metadata (optional file)
+        // Parse Info.plist and Entitlements into a "metadata" dictionary
+        var metadata: [String: Any] = [:]
         if FileManager.default.fileExists(atPath: appProject.darwinInfoPlist.path) {
             let infoPlistData = try parseInfoPlist(at: appProject.darwinInfoPlist)
             if !infoPlistData.isEmpty {
-                ios["infoPlist"] = infoPlistData
+                metadata["infoPlist"] = infoPlistData
             }
             let xcstringsURL = FileManager.default.fileExists(atPath: appProject.darwinInfoPlistXcstrings.path) ? appProject.darwinInfoPlistXcstrings : nil
             let permissions = try extractIOSPermissions(at: appProject.darwinInfoPlist, xcstringsURL: xcstringsURL)
@@ -190,31 +248,34 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
                 ios["permissions"] = permissions
             }
         }
-
-        // Parse Entitlements.plist
         if FileManager.default.fileExists(atPath: appProject.darwinEntitlementsPlist.path) {
             let entitlements = try parseEntitlements(at: appProject.darwinEntitlementsPlist)
             if !entitlements.isEmpty {
-                ios["entitlements"] = entitlements
+                metadata["entitlements"] = entitlements
             }
+        }
+        if !metadata.isEmpty {
+            ios["metadata"] = metadata
         }
 
         // Parse localized fastlane metadata
         let localizedMeta = parseFastlaneMetadata(folder: appProject.darwinFastlaneMetadataFolder, platform: .ios)
-        for (key, locales) in localizedMeta {
-            ios[key] = locales
+        for (key, value) in localizedMeta {
+            ios[key] = value
         }
 
-        // App icon: largest PNG in AppIcon.appiconset
+        // Assets: icon, screenshots
+        var assets: [String: Any] = [:]
         if let iconRef = findLargestPNG(in: appProject.darwinAppIconFolder, relativeTo: projectRoot) {
-            ios["icon"] = iconRef.asDictionary
+            assets["icon"] = iconRef.asDictionary
         }
-
-        // Screenshots: Darwin/fastlane/screenshots/{locale}/*.png
         let screenshotDir = appProject.darwinFastlaneFolder.appendingPathComponent("screenshots")
-        let screenshots = collectLocalizedScreenshots(folder: screenshotDir, relativeTo: projectRoot)
+        let screenshots = collectLocalizedScreenshots(folder: screenshotDir, relativeTo: projectRoot, convention: .apple)
         if !screenshots.isEmpty {
-            ios["screenshots"] = screenshots
+            assets["screenshots"] = screenshots
+        }
+        if !assets.isEmpty {
+            ios["assets"] = assets
         }
 
         return ios
@@ -226,17 +287,19 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
         let effectiveAppId = androidAppId ?? bundleId.replacingOccurrences(of: "-", with: "_")
 
         var android: [String: Any] = [
-            "platform": "android",
             "applicationId": effectiveAppId,
             "version": version,
             "buildNumber": buildNumber,
         ]
 
-        if let googlePlayStoreId = googlePlayStoreId, !googlePlayStoreId.isEmpty {
-            android["playStoreId"] = googlePlayStoreId
-            android["playStoreURL"] = "https://play.google.com/store/apps/details?id=\(googlePlayStoreId)"
-        } else {
-            android["playStoreURL"] = "https://play.google.com/store/apps/details?id=\(effectiveAppId)"
+        do {
+            let playId = (googlePlayStoreId?.isEmpty == false ? googlePlayStoreId : nil) ?? effectiveAppId
+            android["channels"] = [
+                "googleplaystore": [
+                    "id": playId,
+                    "url": "https://play.google.com/store/apps/details?id=\(playId)",
+                ] as [String: Any]
+            ] as [String: Any]
         }
 
         // Parse AndroidManifest.xml for permissions and metadata
@@ -247,32 +310,32 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
             }
             let manifestMeta = try parseAndroidManifest(at: appProject.androidManifest)
             if !manifestMeta.isEmpty {
-                android["manifest"] = manifestMeta
+                android["metadata"] = ["manifest": manifestMeta] as [String: Any]
             }
         }
 
         // Parse localized fastlane metadata
         let localizedMeta = parseFastlaneMetadata(folder: appProject.androidFastlaneMetadataFolder, platform: .android)
-        for (key, locales) in localizedMeta {
-            android[key] = locales
+        for (key, value) in localizedMeta {
+            android[key] = value
         }
 
-        // App icon: Android/fastlane/metadata/android/en-US/images/icon.png
+        // Assets: icon, featureGraphic, screenshots
+        var assets: [String: Any] = [:]
         let androidIconURL = appProject.androidFastlaneMetadataFolder.appendingPathComponent("en-US/images/icon.png")
         if let iconRef = ImageResourceRef.from(pngURL: androidIconURL, relativeTo: projectRoot) {
-            android["icon"] = iconRef.asDictionary
+            assets["icon"] = iconRef.asDictionary
         }
-
-        // Feature graphic: Android/fastlane/metadata/android/{locale}/images/featureGraphic.png
-        let featureGraphics = collectLocalizedImages(named: "featureGraphic.png", subpath: "images", metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot)
+        let featureGraphics = collectLocalizedImages(named: "featureGraphic.png", subpath: "images", metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot, convention: .google)
         if !featureGraphics.isEmpty {
-            android["featureGraphic"] = featureGraphics
+            assets["featureGraphic"] = featureGraphics
         }
-
-        // Screenshots: Android/fastlane/metadata/android/{locale}/images/phoneScreenshots/
-        let screenshots = collectAndroidScreenshots(metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot)
+        let screenshots = collectAndroidScreenshots(metadataFolder: appProject.androidFastlaneMetadataFolder, relativeTo: projectRoot, convention: .google)
         if !screenshots.isEmpty {
-            android["screenshots"] = screenshots
+            assets["screenshots"] = screenshots
+        }
+        if !assets.isEmpty {
+            android["assets"] = assets
         }
 
         return android
@@ -298,7 +361,7 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
         return result
     }
 
-    func extractIOSPermissions(at plistURL: URL, xcstringsURL: URL?, defaultLocale: String = "en-US") throws -> [[String: Any]] {
+    func extractIOSPermissions(at plistURL: URL, xcstringsURL: URL?, defaultLocale: String = "en") throws -> [[String: Any]] {
         let data = try Data(contentsOf: plistURL)
         guard let plist = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
             throw error("Info.plist at \(plistURL.path) is not a valid dictionary plist")
@@ -316,7 +379,7 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
             // Merge translations from xcstrings
             if let localizations = xcstringsTranslations[key] {
                 for (locale, translation) in localizations {
-                    let normalizedLocale = Self.normalizeLocale(locale)
+                    let normalizedLocale = Self.normalizeLocale(locale, convention: .apple)
                     descriptions[normalizedLocale] = translation
                 }
             }
@@ -409,20 +472,22 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
                                    "privacy_url", "support_url", "marketing_url"]
     static let androidMetadataFiles = ["title", "short_description", "full_description"]
 
-    func parseFastlaneMetadata(folder: URL, platform: MetadataPlatform) -> [String: [String: String]] {
+    func parseFastlaneMetadata(folder: URL, platform: MetadataPlatform) -> [String: Any] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: folder.path) else { return [:] }
         guard let locales = try? fm.contentsOfDirectory(atPath: folder.path) else { return [:] }
 
         let metadataFiles = platform == .ios ? Self.iosMetadataFiles : Self.androidMetadataFiles
-        var result: [String: [String: String]] = [:]
+        var stringResults: [String: [String: String]] = [:]
+        var arrayResults: [String: [String: [String]]] = [:]
 
         for locale in locales.sorted() {
             let localeDir = folder.appendingPathComponent(locale)
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: localeDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
 
-            let normalizedLocale = Self.normalizeLocale(locale)
+            let convention: LocaleConvention = platform == .ios ? .apple : .google
+            let normalizedLocale = Self.normalizeLocale(locale, convention: convention)
 
             for fileName in metadataFiles {
                 let filePath = localeDir.appendingPathComponent(fileName + ".txt")
@@ -431,13 +496,22 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
                       !content.isEmpty else { continue }
 
                 let key = Self.normalizeMetadataKey(fileName, platform: platform)
-                if result[key] == nil {
-                    result[key] = [:]
+
+                // Keywords are split into arrays
+                if key == "keywords" {
+                    let keywords = content.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty }
+                    if arrayResults[key] == nil { arrayResults[key] = [:] }
+                    arrayResults[key]?[normalizedLocale] = keywords
+                } else {
+                    if stringResults[key] == nil { stringResults[key] = [:] }
+                    stringResults[key]?[normalizedLocale] = content
                 }
-                result[key]?[normalizedLocale] = content
             }
         }
 
+        var result: [String: Any] = [:]
+        for (key, value) in stringResults { result[key] = value }
+        for (key, value) in arrayResults { result[key] = value }
         return result
     }
 
@@ -456,58 +530,193 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
 
     // MARK: - Locale Normalization
 
-    /// Normalize Apple/iOS locale codes to Android/Play Store codes.
-    /// Apple uses codes like "zh-Hans", "zh-Hant", "pt-BR", "ar-SA".
-    /// Android uses codes like "zh-CN", "zh-TW", "pt-BR", "ar".
-    /// See: https://support.google.com/googleplay/android-developer/answer/9844778
-    static func normalizeLocale(_ locale: String) -> String {
-        // Apple script subtag → Android region subtag mappings
-        let scriptMappings: [String: String] = [
-            "zh-Hans": "zh-CN",
-            "zh-Hant": "zh-TW",
-            "zh-Hant-TW": "zh-TW",
-            "zh-Hant-HK": "zh-HK",
+    /// The platform convention for locale codes in fastlane metadata directories.
+    enum LocaleConvention {
+        /// Apple App Store locale codes (e.g. "ar-SA", "zh-Hans", "en-US").
+        /// Reference: https://docs.fastlane.tools/actions/appstore/#available-language-codes
+        case apple
+        /// Google Play Store locale codes (e.g. "ar", "zh-CN", "en-US").
+        /// Reference: https://support.google.com/googleplay/android-developer/answer/9844778
+        case google
+    }
+
+    /// Normalize a platform-specific locale code to BCP 47 canonical form.
+    ///
+    /// - Parameters:
+    ///   - locale: The locale code from the platform's fastlane metadata directory.
+    ///   - convention: Which platform's naming convention the locale uses.
+    /// - Returns: The canonical BCP 47 locale code.
+    ///
+    /// To update the mapping tables when Apple or Google add or change their language codes:
+    /// 1. Check the platform reference URL listed in each table's doc comment.
+    /// 2. Add the new code to the appropriate `normalizeLocaleApple()` or `normalizeLocaleGoogle()` table.
+    /// 3. Map it to the BCP 47 canonical form (typically the shortest unambiguous subtag).
+    /// 4. Update the test cases in `testLocaleNormalization()` to cover the new code.
+    static func normalizeLocale(_ locale: String, convention: LocaleConvention) -> String {
+        switch convention {
+        case .apple:  return normalizeLocaleApple(locale)
+        case .google: return normalizeLocaleGoogle(locale)
+        }
+    }
+
+    /// Normalize an Apple App Store locale code to BCP 47 canonical form.
+    ///
+    /// Apple locale codes used in fastlane metadata directories:
+    /// ar-SA, ca, cs, da, de-DE, el, en-AU, en-CA, en-GB, en-US, es-ES, es-MX,
+    /// fi, fr-CA, fr-FR, he, hi, hr, hu, id, it, ja, ko, ms, nl-NL, no, pl,
+    /// pt-BR, pt-PT, ro, ru, sk, sv, th, tr, uk, vi, zh-Hans, zh-Hant
+    ///
+    /// Source: https://developer.apple.com/documentation/appstoreconnectapi/managing-metadata-in-your-app-by-using-locale-shortcodes and https://docs.fastlane.tools/actions/appstore/#available-language-codes
+    static func normalizeLocaleApple(_ locale: String) -> String {
+        let appleToCanonical: [String: String] = [
+            "ar-SA":   "ar",       // Arabic (Saudi Arabia) → Arabic
+            "ca":      "ca",       // Catalan
+            "cs":      "cs",       // Czech
+            "da":      "da",       // Danish
+            "de-DE":   "de",       // German (Germany) → German
+            "el":      "el",       // Greek
+            "en-AU":   "en-AU",    // English (Australia)
+            "en-CA":   "en-CA",    // English (Canada)
+            "en-GB":   "en-GB",    // English (UK)
+            "en-US":   "en",       // English (US) → English (default)
+            "es-ES":   "es",       // Spanish (Spain) → Spanish
+            "es-MX":   "es-MX",    // Spanish (Mexico)
+            "fi":      "fi",       // Finnish
+            "fr-CA":   "fr-CA",    // French (Canada)
+            "fr-FR":   "fr",       // French (France) → French
+            "he":      "he",       // Hebrew
+            "hi":      "hi",       // Hindi
+            "hr":      "hr",       // Croatian
+            "hu":      "hu",       // Hungarian
+            "id":      "id",       // Indonesian
+            "it":      "it",       // Italian
+            "ja":      "ja",       // Japanese
+            "ko":      "ko",       // Korean
+            "ms":      "ms",       // Malay
+            "nl-NL":   "nl",       // Dutch (Netherlands) → Dutch
+            "no":      "no",       // Norwegian
+            "pl":      "pl",       // Polish
+            "pt-BR":   "pt-BR",    // Portuguese (Brazil)
+            "pt-PT":   "pt",       // Portuguese (Portugal) → Portuguese
+            "ro":      "ro",       // Romanian
+            "ru":      "ru",       // Russian
+            "sk":      "sk",       // Slovak
+            "sv":      "sv",       // Swedish
+            "th":      "th",       // Thai
+            "tr":      "tr",       // Turkish
+            "uk":      "uk",       // Ukrainian
+            "vi":      "vi",       // Vietnamese
+            "zh-Hans": "zh-Hans",  // Chinese Simplified
+            "zh-Hant": "zh-Hant",  // Chinese Traditional
         ]
 
-        if let mapped = scriptMappings[locale] {
-            return mapped
-        }
+        return appleToCanonical[locale] ?? locale
+    }
 
-        // Apple sometimes uses 3-letter region subtags that Android doesn't use
-        let simplifyMappings: [String: String] = [
-            "ar-SA": "ar",
-            "ca-ES": "ca",
-            "cs-CZ": "cs",
-            "da-DK": "da",
-            "el-GR": "el",
-            "fi-FI": "fi",
-            "he-IL": "iw-IL",  // Android uses "iw" for Hebrew
-            "hi-IN": "hi-IN",
-            "hr-HR": "hr",
-            "hu-HU": "hu",
-            "id-ID": "id",
-            "ja-JP": "ja-JP",
-            "ko-KR": "ko-KR",
-            "ms-MY": "ms-MY",
-            "nb-NO": "no-NO",  // Norwegian Bokmal → "no" on Android
-            "nl-NL": "nl-NL",
-            "pl-PL": "pl-PL",
-            "pt-PT": "pt-PT",
-            "ro-RO": "ro",
-            "ru-RU": "ru-RU",
-            "sk-SK": "sk",
-            "sv-SE": "sv-SE",
-            "th-TH": "th",
-            "tr-TR": "tr-TR",
-            "uk-UA": "uk",
-            "vi-VN": "vi",
+    /// Normalize a Google Play Store locale code to BCP 47 canonical form.
+    ///
+    /// Google locale codes used in fastlane metadata directories:
+    /// af, sq, am, ar, hy-AM, az-AZ, bn-BD, eu-ES, be, bg, my-MM, ca, zh-HK,
+    /// zh-CN, zh-TW, hr, cs-CZ, da-DK, nl-NL, en-AU, en-CA, en-US, en-GB,
+    /// en-IN, en-SG, en-ZA, et, fil, fi-FI, fr-CA, fr-FR, gl-ES, ka-GE, de-DE,
+    /// el-GR, gu, iw-IL, hi-IN, hu-HU, is-IS, id, it-IT, ja-JP, kn-IN, kk,
+    /// km-KH, ko-KR, ky-KG, lo-LA, lv, lt, mk-MK, ms-MY, ms, ml-IN, mr-IN,
+    /// mn-MN, ne-NP, no-NO, fa, fa-AE, fa-AF, fa-IR, pl-PL, pt-BR, pt-PT, pa,
+    /// ro, rm, ru-RU, sr, si-LK, sk, sl, es-419, es-ES, es-US, sw, sv-SE,
+    /// ta-IN, te-IN, th, tr-TR, uk, ur, vi
+    ///
+    /// Source: https://support.google.com/googleplay/android-developer/answer/9844778
+    static func normalizeLocaleGoogle(_ locale: String) -> String {
+        let googleToCanonical: [String: String] = [
+            "af":      "af",       // Afrikaans
+            "am":      "am",       // Amharic
+            "ar":      "ar",       // Arabic
+            "az-AZ":   "az",       // Azerbaijani
+            "be":      "be",       // Belarusian
+            "bg":      "bg",       // Bulgarian
+            "bn-BD":   "bn",       // Bengali
+            "ca":      "ca",       // Catalan
+            "cs-CZ":   "cs",       // Czech
+            "da-DK":   "da",       // Danish
+            "de-DE":   "de",       // German
+            "el-GR":   "el",       // Greek
+            "en-AU":   "en-AU",    // English (Australia)
+            "en-CA":   "en-CA",    // English (Canada)
+            "en-GB":   "en-GB",    // English (UK)
+            "en-IN":   "en-IN",    // English (India)
+            "en-SG":   "en-SG",    // English (Singapore)
+            "en-US":   "en",       // English (US) → English (default)
+            "en-ZA":   "en-ZA",    // English (South Africa)
+            "es-419":  "es-419",   // Spanish (Latin America)
+            "es-ES":   "es",       // Spanish (Spain) → Spanish
+            "es-US":   "es-US",    // Spanish (US)
+            "et":      "et",       // Estonian
+            "eu-ES":   "eu",       // Basque
+            "fa-AE":   "fa",       // Persian (UAE) → Persian
+            "fa-AF":   "fa",       // Persian (Afghanistan) → Persian
+            "fa-IR":   "fa",       // Persian (Iran) → Persian
+            "fa":      "fa",       // Persian
+            "fi-FI":   "fi",       // Finnish
+            "fil":     "fil",      // Filipino
+            "fr-CA":   "fr-CA",    // French (Canada)
+            "fr-FR":   "fr",       // French (France) → French
+            "gl-ES":   "gl",       // Galician
+            "gu":      "gu",       // Gujarati
+            "hi-IN":   "hi",       // Hindi
+            "hr":      "hr",       // Croatian
+            "hu-HU":   "hu",       // Hungarian
+            "hy-AM":   "hy",       // Armenian
+            "id":      "id",       // Indonesian
+            "is-IS":   "is",       // Icelandic
+            "it-IT":   "it",       // Italian
+            "iw-IL":   "he",       // Hebrew (legacy "iw" code)
+            "ja-JP":   "ja",       // Japanese
+            "ka-GE":   "ka",       // Georgian
+            "kk":      "kk",       // Kazakh
+            "km-KH":   "km",       // Khmer
+            "kn-IN":   "kn",       // Kannada
+            "ko-KR":   "ko",       // Korean
+            "ky-KG":   "ky",       // Kyrgyz
+            "lo-LA":   "lo",       // Lao
+            "lt":      "lt",       // Lithuanian
+            "lv":      "lv",       // Latvian
+            "mk-MK":   "mk",       // Macedonian
+            "ml-IN":   "ml",       // Malayalam
+            "mn-MN":   "mn",       // Mongolian
+            "mr-IN":   "mr",       // Marathi
+            "ms-MY":   "ms",       // Malay (Malaysia) → Malay
+            "ms":      "ms",       // Malay
+            "my-MM":   "my",       // Burmese
+            "ne-NP":   "ne",       // Nepali
+            "nl-NL":   "nl",       // Dutch
+            "no-NO":   "no",       // Norwegian
+            "pa":      "pa",       // Punjabi
+            "pl-PL":   "pl",       // Polish
+            "pt-BR":   "pt-BR",    // Portuguese (Brazil)
+            "pt-PT":   "pt",       // Portuguese (Portugal) → Portuguese
+            "rm":      "rm",       // Romansh
+            "ro":      "ro",       // Romanian
+            "ru-RU":   "ru",       // Russian
+            "si-LK":   "si",       // Sinhala
+            "sk":      "sk",       // Slovak
+            "sl":      "sl",       // Slovenian
+            "sq":      "sq",       // Albanian
+            "sr":      "sr",       // Serbian
+            "sv-SE":   "sv",       // Swedish
+            "sw":      "sw",       // Swahili
+            "ta-IN":   "ta",       // Tamil
+            "te-IN":   "te",       // Telugu
+            "th":      "th",       // Thai
+            "tr-TR":   "tr",       // Turkish
+            "uk":      "uk",       // Ukrainian
+            "ur":      "ur",       // Urdu
+            "vi":      "vi",       // Vietnamese
+            "zh-CN":   "zh-Hans",  // Chinese (China) → Chinese Simplified
+            "zh-HK":   "zh-Hant",  // Chinese (Hong Kong) → Chinese Traditional
+            "zh-TW":   "zh-Hant",  // Chinese (Taiwan) → Chinese Traditional
         ]
 
-        if let mapped = simplifyMappings[locale] {
-            return mapped
-        }
-
-        return locale
+        return googleToCanonical[locale] ?? locale
     }
 }
 
@@ -597,7 +806,7 @@ extension MetaIndexCommand {
     /// Collect a single named image file across locale directories.
     /// Returns a locale → ImageResourceRef dictionary.
     /// Path: {metadataFolder}/{locale}/{subpath}/{fileName}
-    func collectLocalizedImages(named fileName: String, subpath: String, metadataFolder: URL, relativeTo root: URL) -> [String: [String: Any]] {
+    func collectLocalizedImages(named fileName: String, subpath: String, metadataFolder: URL, relativeTo root: URL, convention: MetaIndexCommand.LocaleConvention) -> [String: [String: Any]] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: metadataFolder.path) else { return [:] }
         guard let locales = try? fm.contentsOfDirectory(atPath: metadataFolder.path) else { return [:] }
@@ -609,7 +818,7 @@ extension MetaIndexCommand {
                 .appendingPathComponent(fileName)
             if fm.fileExists(atPath: imageURL.path),
                let ref = ImageResourceRef.from(pngURL: imageURL, relativeTo: root) {
-                result[Self.normalizeLocale(locale)] = ref.asDictionary
+                result[MetaIndexCommand.normalizeLocale(locale, convention: convention)] = ref.asDictionary
             }
         }
         return result
@@ -617,8 +826,8 @@ extension MetaIndexCommand {
 
     // MARK: - Screenshot Discovery
 
-    /// Collect iOS screenshots from Darwin/fastlane/screenshots/{locale}/*.png
-    func collectLocalizedScreenshots(folder: URL, relativeTo root: URL) -> [String: [[String: Any]]] {
+    /// Collect localized screenshots from a fastlane screenshots directory.
+    func collectLocalizedScreenshots(folder: URL, relativeTo root: URL, convention: MetaIndexCommand.LocaleConvention) -> [String: [[String: Any]]] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: folder.path) else { return [:] }
         guard let locales = try? fm.contentsOfDirectory(atPath: folder.path) else { return [:] }
@@ -630,7 +839,7 @@ extension MetaIndexCommand {
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: localeDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
 
-            let normalizedLocale = Self.normalizeLocale(locale)
+            let normalizedLocale = MetaIndexCommand.normalizeLocale(locale, convention: convention)
             var refs: [[String: Any]] = []
 
             if let files = try? fm.contentsOfDirectory(atPath: localeDir.path) {
@@ -651,7 +860,7 @@ extension MetaIndexCommand {
     }
 
     /// Collect Android screenshots from Android/fastlane/metadata/android/{locale}/images/phoneScreenshots/*.png
-    func collectAndroidScreenshots(metadataFolder: URL, relativeTo root: URL) -> [String: [[String: Any]]] {
+    func collectAndroidScreenshots(metadataFolder: URL, relativeTo root: URL, convention: MetaIndexCommand.LocaleConvention) -> [String: [[String: Any]]] {
         let fm = FileManager.default
         guard fm.fileExists(atPath: metadataFolder.path) else { return [:] }
         guard let locales = try? fm.contentsOfDirectory(atPath: metadataFolder.path) else { return [:] }
@@ -664,7 +873,7 @@ extension MetaIndexCommand {
             var isDir: ObjCBool = false
             guard fm.fileExists(atPath: screenshotDir.path, isDirectory: &isDir), isDir.boolValue else { continue }
 
-            let normalizedLocale = Self.normalizeLocale(locale)
+            let normalizedLocale = MetaIndexCommand.normalizeLocale(locale, convention: convention)
             var refs: [[String: Any]] = []
 
             if let files = try? fm.contentsOfDirectory(atPath: screenshotDir.path) {
@@ -732,23 +941,87 @@ enum AppIndexGenerator {
             #endif
         }
 
+        // Extract link-type keys from platform dicts into a top-level "links" dictionary.
+        let linkKeyMapping: [String: String] = [
+            "privacyURL": "privacy",
+            "supportURL": "support",
+            "marketingURL": "marketing",
+        ]
+
+        var links: [String: Any] = [:]
+        for (metaKey, linkKey) in linkKeyMapping {
+            var merged: [String: String] = [:]
+            if let iosLocales = iosDict.removeValue(forKey: metaKey) as? [String: String] {
+                for (locale, url) in iosLocales { merged[locale] = url }
+            }
+            if let androidLocales = androidDict.removeValue(forKey: metaKey) as? [String: String] {
+                for (locale, url) in androidLocales {
+                    if merged[locale] == nil { merged[locale] = url }
+                }
+            }
+            if !merged.isEmpty {
+                links[linkKey] = collapseToDefault(merged)
+            }
+        }
+
+        // Promote shared metadata fields: if a field appears in only one platform,
+        // or in both platforms with identical content, move it to the app level.
+        let promotableKeys = ["title", "subtitle", "description", "keywords", "releaseNotes"]
         var appDict: [String: Any] = [
             "name": productName,
-            "platforms": [
-                "ios": iosDict,
-                "android": androidDict,
-            ] as [String: Any],
         ]
+
+        for key in promotableKeys {
+            let iosVal = iosDict[key]
+            let androidVal = androidDict[key]
+
+            var promoted: Any?
+            if let iosVal = iosVal, let androidVal = androidVal {
+                // Both platforms have this key — promote only if identical
+                if let iosData = try? JSONSerialization.data(withJSONObject: iosVal, options: .sortedKeys),
+                   let androidData = try? JSONSerialization.data(withJSONObject: androidVal, options: .sortedKeys),
+                   iosData == androidData {
+                    promoted = iosVal
+                    iosDict.removeValue(forKey: key)
+                    androidDict.removeValue(forKey: key)
+                }
+            } else if let onlyVal = iosVal ?? androidVal {
+                // Only one platform has this key — promote it
+                promoted = onlyVal
+                iosDict.removeValue(forKey: key)
+                androidDict.removeValue(forKey: key)
+            }
+
+            // Collapse localized dictionaries when all values are identical
+            if let dict = promoted as? [String: String] {
+                appDict[key] = collapseToDefault(dict)
+            } else if let promoted = promoted {
+                appDict[key] = promoted
+            }
+        }
+
+        appDict["platforms"] = [
+            "ios": iosDict,
+            "android": androidDict,
+        ] as [String: Any]
+
+        if !links.isEmpty {
+            appDict["links"] = links
+        }
 
         // Add source repository info from .git/config
         if let originURL = cmd.parseGitOriginURL(projectRoot: projectURL) {
             let browseURL = MetaIndexCommand.gitRemoteToHTTPS(originURL)
-            var source: [String: String] = [
+            var source: [String: Any] = [
                 "url": originURL,
-            ]
+            ] as [String: Any]
             if browseURL.contains("github.com") {
                 source["release"] = "\(browseURL)/releases/tag/\(version)/"
                 source["assets"] = "https://raw.githubusercontent.com/\(browseURL.components(separatedBy: "github.com/").last ?? "")/refs/tags/\(version)/"
+            }
+            // Detect license from LICENSE file
+            if let license = cmd.detectLicense(projectRoot: projectURL) {
+                source["license"] = license
             }
             appDict["source"] = source
         }
@@ -763,6 +1036,17 @@ enum AppIndexGenerator {
             "generator": "skip/\(skipVersion)",
             "apps": [appDict],
         ] as [String: Any]
+    }
+
+    /// Collapse a localized dictionary when all values are identical.
+    /// When every locale points to the same value, returns `{ "en": value }`
+    /// instead of repeating the same URL for every locale.
+    private static func collapseToDefault(_ localized: [String: String]) -> [String: String] {
+        let uniqueValues = Set(localized.values)
+        if uniqueValues.count == 1, let value = uniqueValues.first {
+            return ["en": value]
+        }
+        return localized
     }
 
     /// Write the app index JSON to a file and optionally create a symlink in the app Resources folder.

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -517,7 +517,7 @@ public struct ImageResourceRef: Codable, Equatable, Sendable {
     public var mimeType: String?
     public var location: String
     public var size: Int64
-    public var hash: String
+    public var digest: String
     public var width: Int
     public var height: Int
     public var caption: String?
@@ -527,7 +527,7 @@ public struct ImageResourceRef: Codable, Equatable, Sendable {
         var dict: [String: Any] = [
             "location": location,
             "size": size,
-            "hash": hash,
+            "digest": digest,
             "width": width,
             "height": height,
         ]
@@ -544,7 +544,7 @@ public struct ImageResourceRef: Codable, Equatable, Sendable {
         let hash = data.SHA256Hash()
         let (width, height) = parsePNGDimensions(data)
         let location = relativePath(from: root.standardized.path, to: pngURL.standardized.path)
-        return ImageResourceRef(mimeType: "image/png", location: location, size: fileSize, hash: hash, width: width, height: height)
+        return ImageResourceRef(mimeType: "image/png", location: location, size: fileSize, digest: "sha256:\(hash)", width: width, height: height)
     }
 
     /// Parse width and height from a PNG file's IHDR chunk.
@@ -734,8 +734,6 @@ enum AppIndexGenerator {
 
         var appDict: [String: Any] = [
             "name": productName,
-            "version": version,
-            "buildNumber": buildNumber,
             "platforms": [
                 "ios": iosDict,
                 "android": androidDict,
@@ -755,7 +753,16 @@ enum AppIndexGenerator {
             appDict["source"] = source
         }
 
-        return ["app": appDict]
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime]
+
+        return [
+            "$schema": "https://appfair.org/schemas/appindex/v1.json",
+            "specVersion": "1.0",
+            "generated": dateFormatter.string(from: Date()),
+            "generator": "skip/\(skipVersion)",
+            "apps": [appDict],
+        ] as [String: Any]
     }
 
     /// Write the app index JSON to a file and optionally create a symlink in the app Resources folder.

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -451,7 +451,7 @@ public struct ImageResourceRef: Codable, Equatable, Sendable {
         guard fileSize > 0 else { return nil }
         let hash = data.SHA256Hash()
         let (width, height) = parsePNGDimensions(data)
-        let location = relativePath(of: pngURL, to: root)
+        let location = relativePath(from: root.standardized.path, to: pngURL.standardized.path)
         return ImageResourceRef(mimeType: "image/png", location: location, size: fileSize, hash: hash, width: width, height: height)
     }
 
@@ -473,15 +473,6 @@ public struct ImageResourceRef: Codable, Equatable, Sendable {
         return (width, height)
     }
 
-    /// Compute a relative path from a file URL to a root URL.
-    static func relativePath(of fileURL: URL, to root: URL) -> String {
-        let filePath = fileURL.standardized.path
-        let rootPath = root.standardized.path.hasSuffix("/") ? root.standardized.path : root.standardized.path + "/"
-        if filePath.hasPrefix(rootPath) {
-            return String(filePath.dropFirst(rootPath.count))
-        }
-        return filePath
-    }
 }
 
 @available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
@@ -681,22 +672,7 @@ enum AppIndexGenerator {
         return outputURL
     }
 
-    /// Compute a relative path for symlink creation.
-    private static func relativePath(from fromDir: String, to toPath: String) -> String {
-        let fromComponents = URL(fileURLWithPath: fromDir).standardized.pathComponents
-        let toComponents = URL(fileURLWithPath: toPath).standardized.pathComponents
-
-        var commonLength = 0
-        while commonLength < fromComponents.count && commonLength < toComponents.count
-                && fromComponents[commonLength] == toComponents[commonLength] {
-            commonLength += 1
-        }
-
-        let ups = fromComponents.count - commonLength
-        var parts = Array(repeating: "..", count: ups)
-        parts.append(contentsOf: toComponents[commonLength...])
-        return parts.joined(separator: "/")
-    }
+    // relativePath(from:to:) is defined in Utilities.swift
 }
 
 private struct AppIndexError: LocalizedError {

--- a/Sources/SkipBuild/Commands/MetaCommand.swift
+++ b/Sources/SkipBuild/Commands/MetaCommand.swift
@@ -101,56 +101,7 @@ The output uses Android/Play Store locale codes (e.g. "zh-CN" instead of Apple's
 
     func generateAppCatalog(projectURL: URL, includeSBOM: Bool, with out: MessageQueue) async throws -> [String: Any] {
         let packageJSON = try await parseSwiftPackage(with: out, at: projectURL.path)
-        let moduleNames = packageJSON.targets.compactMap(\.a).filter({ $0.type == "regular" }).filter({ $0.pluginUsages != nil }).map(\.name)
-        guard let appModuleName = moduleNames.first else {
-            throw error("No Skip module targets found in package \(packageJSON.name)")
-        }
-
-        let appProject = AppProjectLayout(moduleName: appModuleName, root: projectURL, check: AppProjectLayout.noURLChecks)
-
-        // Parse Skip.env for shared configuration
-        let env = try parseSkipEnv(at: appProject.skipEnv)
-
-        let bundleId = env["PRODUCT_BUNDLE_IDENTIFIER"] ?? ""
-        let version = env["MARKETING_VERSION"] ?? "0.0.1"
-        let buildNumber = env["CURRENT_PROJECT_VERSION"] ?? "1"
-        let productName = env["PRODUCT_NAME"] ?? appModuleName
-        let androidAppId = env["ANDROID_APPLICATION_ID"]
-        let appleStoreId = env["APPLE_APP_STORE_ID"]
-        let googlePlayStoreId = env["GOOGLE_PLAY_STORE_ID"]
-
-        // Build per-platform metadata
-        var iosDict = try buildIOSMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, version: version, buildNumber: buildNumber, appleStoreId: appleStoreId)
-        var androidDict = try buildAndroidMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, androidAppId: androidAppId, version: version, buildNumber: buildNumber, googlePlayStoreId: googlePlayStoreId)
-
-        // Include SBOM if requested
-        if includeSBOM {
-            #if canImport(SkipDriveExternal)
-            let outputDir = try AbsolutePath(validating: NSTemporaryDirectory())
-            let sbomFiles = try await SBOMGenerator.generateSBOMFiles(generateIOS: true, generateAndroid: true, projectPath: projectURL.path, packageName: packageJSON.name, packageJSON: packageJSON, outputDirAbsolute: outputDir, command: self, out: out)
-            for file in sbomFiles {
-                let data = try Data(contentsOf: file)
-                let json = try JSONSerialization.jsonObject(with: data)
-                if file.lastPathComponent.contains("darwin") || file.lastPathComponent.contains("ios") {
-                    iosDict["sbom"] = json
-                } else if file.lastPathComponent.contains("android") {
-                    androidDict["sbom"] = json
-                }
-            }
-            #endif
-        }
-
-        let appDict: [String: Any] = [
-            "name": productName,
-            "version": version,
-            "buildNumber": buildNumber,
-            "platforms": [
-                "ios": iosDict,
-                "android": androidDict,
-            ] as [String: Any],
-        ]
-
-        return ["app": appDict]
+        return try await AppIndexGenerator.generateAppIndex(projectURL: projectURL, packageJSON: packageJSON, includeSBOM: includeSBOM, command: self, out: out)
     }
 
     // MARK: - Skip.env Parsing
@@ -645,6 +596,108 @@ extension MetaIndexCommand {
 
         return result
     }
+}
+
+// MARK: - Shared App Index Generator
+
+/// Shared logic for generating an app index JSON document, used by both
+/// `skip meta index` and `skip export --appindex`.
+@available(macOS 13, iOS 16, tvOS 16, watchOS 8, *)
+enum AppIndexGenerator {
+    static let appIndexFilename = "appindex.json"
+
+    /// Generate the app index dictionary from a project.
+    static func generateAppIndex<C: StreamingCommand & OutputOptionsCommand>(projectURL: URL, packageJSON: PackageManifest, includeSBOM: Bool, command: C, out: MessageQueue) async throws -> [String: Any] {
+        let moduleNames = packageJSON.targets.compactMap(\.a).filter({ $0.type == "regular" }).filter({ $0.pluginUsages != nil }).map(\.name)
+        guard let appModuleName = moduleNames.first else {
+            throw AppIndexError(message: "No Skip module targets found in package \(packageJSON.name)")
+        }
+
+        let appProject = AppProjectLayout(moduleName: appModuleName, root: projectURL, check: AppProjectLayout.noURLChecks)
+        let cmd = MetaIndexCommand()
+
+        let env = try cmd.parseSkipEnv(at: appProject.skipEnv)
+
+        let bundleId = env["PRODUCT_BUNDLE_IDENTIFIER"] ?? ""
+        let version = env["MARKETING_VERSION"] ?? "0.0.1"
+        let buildNumber = env["CURRENT_PROJECT_VERSION"] ?? "1"
+        let productName = env["PRODUCT_NAME"] ?? appModuleName
+        let androidAppId = env["ANDROID_APPLICATION_ID"]
+        let appleStoreId = env["APPLE_APP_STORE_ID"]
+        let googlePlayStoreId = env["GOOGLE_PLAY_STORE_ID"]
+
+        var iosDict = try cmd.buildIOSMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, version: version, buildNumber: buildNumber, appleStoreId: appleStoreId)
+        var androidDict = try cmd.buildAndroidMetadata(appProject: appProject, projectRoot: projectURL, productName: productName, bundleId: bundleId, androidAppId: androidAppId, version: version, buildNumber: buildNumber, googlePlayStoreId: googlePlayStoreId)
+
+        if includeSBOM {
+            #if canImport(SkipDriveExternal)
+            let outputDir = try AbsolutePath(validating: NSTemporaryDirectory())
+            let sbomFiles = try await SBOMGenerator.generateSBOMFiles(generateIOS: true, generateAndroid: true, projectPath: projectURL.path, packageName: packageJSON.name, packageJSON: packageJSON, outputDirAbsolute: outputDir, command: command, out: out)
+            for file in sbomFiles {
+                let data = try Data(contentsOf: file)
+                let json = try JSONSerialization.jsonObject(with: data)
+                if file.lastPathComponent.contains("darwin") || file.lastPathComponent.contains("ios") {
+                    iosDict["sbom"] = json
+                } else if file.lastPathComponent.contains("android") {
+                    androidDict["sbom"] = json
+                }
+            }
+            #endif
+        }
+
+        let appDict: [String: Any] = [
+            "name": productName,
+            "version": version,
+            "buildNumber": buildNumber,
+            "platforms": [
+                "ios": iosDict,
+                "android": androidDict,
+            ] as [String: Any],
+        ]
+
+        return ["app": appDict]
+    }
+
+    /// Write the app index JSON to a file and optionally create a symlink in the app Resources folder.
+    static func writeAppIndex(_ catalog: [String: Any], to outputURL: URL, linkResource: Bool, appModuleName: String, projectURL: URL, out: MessageQueue) async throws -> URL {
+        let jsonData = try JSONSerialization.data(withJSONObject: catalog, options: [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes])
+        try jsonData.write(to: outputURL)
+
+        if linkResource {
+            let resourcesFolder = projectURL.appendingPathComponent("Sources/\(appModuleName)/Resources", isDirectory: true)
+            try FileManager.default.createDirectory(at: resourcesFolder, withIntermediateDirectories: true)
+
+            let linkPath = resourcesFolder.appendingPathComponent(appIndexFilename).path
+            try? FileManager.default.removeItem(atPath: linkPath)
+            let relPath = relativePath(from: resourcesFolder.path, to: outputURL.path)
+            try FileManager.default.createSymbolicLink(atPath: linkPath, withDestinationPath: relPath)
+            await out.write(status: .pass, "Linked \(appIndexFilename) -> \(relPath)")
+        }
+
+        return outputURL
+    }
+
+    /// Compute a relative path for symlink creation.
+    private static func relativePath(from fromDir: String, to toPath: String) -> String {
+        let fromComponents = URL(fileURLWithPath: fromDir).standardized.pathComponents
+        let toComponents = URL(fileURLWithPath: toPath).standardized.pathComponents
+
+        var commonLength = 0
+        while commonLength < fromComponents.count && commonLength < toComponents.count
+                && fromComponents[commonLength] == toComponents[commonLength] {
+            commonLength += 1
+        }
+
+        let ups = fromComponents.count - commonLength
+        var parts = Array(repeating: "..", count: ups)
+        parts.append(contentsOf: toComponents[commonLength...])
+        return parts.joined(separator: "/")
+    }
+}
+
+private struct AppIndexError: LocalizedError {
+    let message: String
+    var errorDescription: String? { message }
 }
 
 // MARK: - Android Manifest XML Parser

--- a/Sources/SkipBuild/Commands/SBOMCommand.swift
+++ b/Sources/SkipBuild/Commands/SBOMCommand.swift
@@ -624,10 +624,12 @@ enum SBOMGenerator {
         for pin in resolved.pins {
             let depSPDXID = "SPDXRef-Package-\(spdxSafeID(pin.identity))"
 
+            let versionInfo = pin.state.version ?? pin.state.branch ?? pin.state.revision
+
             var pkg: [String: Any] = [
                 "SPDXID": depSPDXID,
                 "name": pin.identity,
-                "versionInfo": pin.state.version,
+                "versionInfo": versionInfo,
                 "downloadLocation": pin.location,
                 "filesAnalyzed": false,
                 "supplier": "NOASSERTION",

--- a/Sources/SkipBuild/Commands/SBOMCommand.swift
+++ b/Sources/SkipBuild/Commands/SBOMCommand.swift
@@ -954,24 +954,7 @@ enum SBOMGenerator {
 
 /// Compute a relative path from a directory to a target file path.
 /// Both paths should be absolute. The result is suitable for use as a symlink destination.
-private func relativePath(from fromDir: String, to toPath: String) -> String {
-    let fromComponents = URL(fileURLWithPath: fromDir).standardized.pathComponents
-    let toComponents = URL(fileURLWithPath: toPath).standardized.pathComponents
-
-    // Find the common prefix length
-    var commonLength = 0
-    while commonLength < fromComponents.count && commonLength < toComponents.count
-            && fromComponents[commonLength] == toComponents[commonLength] {
-        commonLength += 1
-    }
-
-    // Number of ".." needed to go up from fromDir to the common ancestor
-    let ups = fromComponents.count - commonLength
-    var parts = Array(repeating: "..", count: ups)
-    // Append the remaining path components from toPath
-    parts.append(contentsOf: toComponents[commonLength...])
-    return parts.joined(separator: "/")
-}
+// relativePath(from:to:) is defined in Utilities.swift
 
 /// Shared license policy for SBOM verification, used by both `skip sbom verify` and `skip verify --sbom`.
 struct SBOMLicensePolicy {

--- a/Sources/SkipBuild/SkipCommand.swift
+++ b/Sources/SkipBuild/SkipCommand.swift
@@ -85,7 +85,7 @@ public struct SkipRunnerExecutor: SkipCommandExecutor {
             ADBCommand.self,
             AndroidCommand.self,
             ExportCommand.self,
-            SBOMCommand.self,
+            MetaCommand.self,
             DevicesCommand.self,
             TestCommand.self,
 
@@ -1317,7 +1317,8 @@ public struct PackageResolved : Hashable, Decodable {
 
         public struct State: Hashable, Decodable {
             public var revision: String
-            public var version: String
+            public var version: String?
+            public var branch: String?
         }
     }
 }

--- a/Sources/SkipBuild/SkipProject.swift
+++ b/Sources/SkipBuild/SkipProject.swift
@@ -1789,6 +1789,7 @@ class AppProjectLayout : FrameworkProjectLayout {
 
     let darwinEntitlementsPlist: URL
     let darwinInfoPlist: URL
+    let darwinInfoPlistXcstrings: URL
     let darwinProjectConfig: URL
     let darwinProjectFolder: URL
     let darwinProjectContents: URL
@@ -1847,6 +1848,7 @@ class AppProjectLayout : FrameworkProjectLayout {
         self.darwinSchemesFolder = darwinProjectFolder.resolve("xcshareddata/xcschemes/", check: optional)
         self.darwinEntitlementsPlist = try darwinFolder.resolve("Entitlements.plist", check: check)
         self.darwinInfoPlist = darwinFolder.resolve("Info.plist", check: optional)
+        self.darwinInfoPlistXcstrings = darwinFolder.resolve("InfoPlist.xcstrings", check: optional)
 
         self.darwinAssetsFolder = try darwinFolder.resolve("Assets.xcassets/", check: check)
         self.darwinAssetsContents = try darwinAssetsFolder.resolve("Contents.json", check: check)
@@ -1974,6 +1976,17 @@ class AppProjectLayout : FrameworkProjectLayout {
 
         try infoPlistContents.write(to: appProject.darwinInfoPlist.createParentDirectory(), atomically: false, encoding: .utf8)
 
+        let infoPlistXcstringsContents = """
+{
+  "sourceLanguage" : "en",
+  "strings" : { },
+  "version" : "1.0"
+}
+
+"""
+        try infoPlistXcstringsContents.write(to: appProject.darwinInfoPlistXcstrings.createParentDirectory(), atomically: false, encoding: .utf8)
+
+
         // create the top-level Skip.env which is the source or truth for Xcode and Gradle
         let skipEnvContents = """
 // The configuration file for your Skip App (https://skip.dev).
@@ -2031,7 +2044,6 @@ GENERATE_INFOPLIST_FILE = YES
 // The user-visible name of the app (localizable)
 //INFOPLIST_KEY_CFBundleDisplayName = App Name
 //INFOPLIST_KEY_LSApplicationCategoryType = public.app-category.utilities
-//INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "This app uses your location to …"
 
 // iOS-specific Info.plist property keys
 INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphone*] = YES
@@ -2044,13 +2056,13 @@ IPHONEOS_DEPLOYMENT_TARGET = \(options.iOSMinVersion)
 MACOSX_DEPLOYMENT_TARGET = \(options.macOSMinVersionCalculated)
 SUPPORTS_MACCATALYST = NO
 
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx
+
 // iPhone + iPad
 TARGETED_DEVICE_FAMILY = 1,2
 
 // iPhone only
 // TARGETED_DEVICE_FAMILY = 1
-
-SWIFT_EMIT_LOC_STRINGS = YES
 
 // the name of the product module; this can be anything, but cannot conflict with any Swift module names
 PRODUCT_MODULE_NAME = $(PRODUCT_NAME:c99extidentifier)App
@@ -2059,8 +2071,6 @@ PRODUCT_MODULE_NAME = $(PRODUCT_NAME:c99extidentifier)App
 // PRODUCT_BUNDLE_IDENTIFIER[config=Debug][sdk=iphoneos*] = cool.beans.BundleIdentifer
 
 SDKROOT = auto
-SUPPORTED_PLATFORMS = iphoneos iphonesimulator macosx
-SWIFT_EMIT_LOC_STRINGS = YES
 
 SWIFT_VERSION = \(swiftVersionMajor)
 
@@ -3158,6 +3168,7 @@ skip gradle -p ../Android ${SKIP_ACTION:-launch}${CONFIGURATION:-Debug}
         496EB72F2A6AE4DE00C1253A /* Skip.env */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Skip.env; path = ../Skip.env; sourceTree = "<group>"; };
         496EB72F2A6AE4DE00C1253B /* \(APP_NAME).xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = \(APP_NAME).xcconfig; sourceTree = "<group>"; };
         496EB72F2A6AE4DE00C1253C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
+        4971EFA92FA4FEA50002D3F7 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
         499AB9082B0581F4005E8330 /* plugins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = plugins; path = ../../Intermediates.noindex/BuildToolPluginIntermediates; sourceTree = BUILT_PRODUCTS_DIR; };
         49F90C2B2A52156200F06D93 /* Main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Main.swift; path = Sources/Main.swift; sourceTree = SOURCE_ROOT; };
         49F90C2F2A52156300F06D93 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -3213,6 +3224,7 @@ skip gradle -p ../Android ${SKIP_ACTION:-launch}${CONFIGURATION:-Debug}
                 49F90C2F2A52156300F06D93 /* Assets.xcassets */,
                 49F90C312A52156300F06D93 /* Entitlements.plist */,
                 4900101C2BACEA710000DE33 /* Info.plist */,
+                4971EFA92FA4FEA50002D3F7 /* InfoPlist.xcstrings */,
             );
             name = App;
             sourceTree = "<group>";
@@ -3280,6 +3292,7 @@ skip gradle -p ../Android ${SKIP_ACTION:-launch}${CONFIGURATION:-Debug}
             isa = PBXResourcesBuildPhase;
             buildActionMask = 2147483647;
             files = (
+                4971EFAA2FA4FEA50002D3F7 /* InfoPlist.xcstrings in Resources */,
                 499CD4402AC5B799001AE8D8 /* Assets.xcassets in Resources */,
                 496BDBEE2B8A7E9C00C09264 /* Localizable.xcstrings in Resources */,
             );
@@ -3356,6 +3369,7 @@ skip gradle -p ../Android ${SKIP_ACTION:-launch}${CONFIGURATION:-Debug}
                 MTL_FAST_MATH = YES;
                 ONLY_ACTIVE_ARCH = YES;
                 SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+                SWIFT_EMIT_LOC_STRINGS = YES;
                 SWIFT_OPTIMIZATION_LEVEL = "-Onone";
             };
             name = Debug;
@@ -3374,6 +3388,7 @@ skip gradle -p ../Android ${SKIP_ACTION:-launch}${CONFIGURATION:-Debug}
                 MTL_ENABLE_DEBUG_INFO = NO;
                 MTL_FAST_MATH = YES;
                 SWIFT_COMPILATION_MODE = wholemodule;
+                SWIFT_EMIT_LOC_STRINGS = YES;
             };
             name = Release;
         };

--- a/Sources/SkipBuild/Utilities.swift
+++ b/Sources/SkipBuild/Utilities.swift
@@ -231,6 +231,31 @@ extension URL {
     }
 }
 
+/// Compute a relative path from one file system location to another.
+///
+/// When `from` is an ancestor of `to`, returns the simple suffix (e.g. `"sub/file.txt"`).
+/// When they diverge, walks up with `..` components (e.g. `"../../other/file.txt"`).
+///
+/// - Parameters:
+///   - from: The directory to compute the path relative to.
+///   - to: The target file or directory.
+/// - Returns: A relative path string suitable for symlinks or display.
+func relativePath(from fromDir: String, to toPath: String) -> String {
+    let fromComponents = URL(fileURLWithPath: fromDir).standardized.pathComponents
+    let toComponents = URL(fileURLWithPath: toPath).standardized.pathComponents
+
+    var commonLength = 0
+    while commonLength < fromComponents.count && commonLength < toComponents.count
+            && fromComponents[commonLength] == toComponents[commonLength] {
+        commonLength += 1
+    }
+
+    let ups = fromComponents.count - commonLength
+    var parts = Array(repeating: "..", count: ups)
+    parts.append(contentsOf: toComponents[commonLength...])
+    return parts.joined(separator: "/")
+}
+
 extension NSRegularExpression {
     /// Returns the array of matches for a string against the regular expression.
     func extract(from string: String, options: NSRegularExpression.MatchingOptions = []) -> [String]? {

--- a/Tests/SkipBuildTests/SkipBuildTests.swift
+++ b/Tests/SkipBuildTests/SkipBuildTests.swift
@@ -155,6 +155,34 @@ final class SkipBuildTests: XCTestCase {
 
     // MARK: - Meta Generate Tests
 
+    func testGitRemoteToHTTPS() {
+        XCTAssertEqual("https://github.com/Org/Repo", MetaIndexCommand.gitRemoteToHTTPS("https://github.com/Org/Repo.git"))
+        XCTAssertEqual("https://github.com/Org/Repo", MetaIndexCommand.gitRemoteToHTTPS("git@github.com:Org/Repo.git"))
+        XCTAssertEqual("https://github.com/Org/Repo", MetaIndexCommand.gitRemoteToHTTPS("https://github.com/Org/Repo"))
+        XCTAssertEqual("https://gitlab.com/Org/Repo", MetaIndexCommand.gitRemoteToHTTPS("git@gitlab.com:Org/Repo.git"))
+    }
+
+    func testParseGitOriginURL() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        try """
+        [core]
+        \trepositoryformatversion = 0
+        \tfilemode = true
+        [remote "origin"]
+        \turl = https://github.com/Example/MyApp.git
+        \tfetch = +refs/heads/*:refs/remotes/origin/*
+        [branch "main"]
+        \tremote = origin
+        """.write(to: tmpDir.appendingPathComponent(".git/config"), atomically: true, encoding: .utf8)
+
+        let url = cmd.parseGitOriginURL(projectRoot: tmpDir)
+        XCTAssertEqual(url, "https://github.com/Example/MyApp.git")
+    }
+
     func testLocaleNormalization() {
         XCTAssertEqual("zh-CN", MetaIndexCommand.normalizeLocale("zh-Hans"))
         XCTAssertEqual("zh-TW", MetaIndexCommand.normalizeLocale("zh-Hant"))
@@ -232,10 +260,47 @@ final class SkipBuildTests: XCTestCase {
         let info = try cmd.parseInfoPlist(at: plistFile)
         XCTAssertEqual(info["ITSAppUsesNonExemptEncryption"] as? Bool, false)
 
-        let permissions = try cmd.extractIOSPermissions(at: plistFile)
+        // Without xcstrings: descriptions use the default locale
+        let permissions = try cmd.extractIOSPermissions(at: plistFile, xcstringsURL: nil)
         XCTAssertEqual(permissions.count, 2)
-        let permKeys = permissions.map { $0["key"]! }.sorted()
+        let permKeys = permissions.compactMap { $0["key"] as? String }.sorted()
         XCTAssertEqual(permKeys, ["NSCameraUsageDescription", "NSLocationWhenInUseUsageDescription"])
+        let cameraDesc = permissions.first(where: { $0["key"] as? String == "NSCameraUsageDescription" })?["description"] as? [String: String]
+        XCTAssertEqual(cameraDesc?["en-US"], "We need camera access for photos")
+
+        // With xcstrings: translations are merged in
+        let xcstringsFile = tmpDir.appendingPathComponent("InfoPlist.xcstrings")
+        try """
+        {
+          "sourceLanguage" : "en",
+          "strings" : {
+            "NSCameraUsageDescription" : {
+              "localizations" : {
+                "fr" : {
+                  "stringUnit" : {
+                    "state" : "translated",
+                    "value" : "Accès caméra pour les photos"
+                  }
+                },
+                "zh-Hans" : {
+                  "stringUnit" : {
+                    "state" : "translated",
+                    "value" : "需要相机权限来拍照"
+                  }
+                }
+              }
+            }
+          },
+          "version" : "1.0"
+        }
+        """.write(to: xcstringsFile, atomically: true, encoding: .utf8)
+
+        let localizedPerms = try cmd.extractIOSPermissions(at: plistFile, xcstringsURL: xcstringsFile)
+        let cameraPerm = localizedPerms.first(where: { $0["key"] as? String == "NSCameraUsageDescription" })
+        let cameraDescs = cameraPerm?["description"] as? [String: String]
+        XCTAssertEqual(cameraDescs?["en-US"], "We need camera access for photos")
+        XCTAssertEqual(cameraDescs?["fr"], "Accès caméra pour les photos")
+        XCTAssertEqual(cameraDescs?["zh-CN"], "需要相机权限来拍照")  // zh-Hans normalized to zh-CN
     }
 
     func testParseAndroidManifest() throws {
@@ -261,8 +326,8 @@ final class SkipBuildTests: XCTestCase {
         let permissions = try cmd.extractAndroidPermissions(at: manifestFile)
         // Should only include non-commented permissions
         XCTAssertEqual(permissions.count, 2)
-        XCTAssertEqual(permissions[0]["name"], "android.permission.INTERNET")
-        XCTAssertEqual(permissions[1]["name"], "android.permission.CAMERA")
+        XCTAssertEqual(permissions[0]["key"], "android.permission.INTERNET")
+        XCTAssertEqual(permissions[1]["key"], "android.permission.CAMERA")
 
         let meta = try cmd.parseAndroidManifest(at: manifestFile)
         XCTAssertEqual(meta["label"] as? String, "${PRODUCT_NAME}")
@@ -438,9 +503,11 @@ final class SkipBuildTests: XCTestCase {
         XCTAssertEqual(ios["appStoreURL"] as? String, "https://apps.apple.com/app/id9876543")
 
         // Check iOS permissions
-        let iosPerms = ios["permissions"] as? [[String: String]]
+        let iosPerms = ios["permissions"] as? [[String: Any]]
         XCTAssertEqual(iosPerms?.count, 1)
-        XCTAssertEqual(iosPerms?.first?["key"], "NSPhotoLibraryUsageDescription")
+        XCTAssertEqual(iosPerms?.first?["key"] as? String, "NSPhotoLibraryUsageDescription")
+        let photoDesc = iosPerms?.first?["description"] as? [String: String]
+        XCTAssertEqual(photoDesc?["en-US"], "Access photos for sharing")
 
         // Check iOS entitlements
         let entitlements = ios["entitlements"] as? [String: Any]
@@ -460,8 +527,8 @@ final class SkipBuildTests: XCTestCase {
         // Check Android permissions
         let androidPerms = android["permissions"] as? [[String: String]]
         XCTAssertEqual(androidPerms?.count, 2)
-        XCTAssertEqual(androidPerms?[0]["name"], "android.permission.INTERNET")
-        XCTAssertEqual(androidPerms?[1]["name"], "android.permission.CAMERA")
+        XCTAssertEqual(androidPerms?[0]["key"], "android.permission.INTERNET")
+        XCTAssertEqual(androidPerms?[1]["key"], "android.permission.CAMERA")
 
         // Check Android localized metadata
         let androidTitle = android["title"] as? [String: String]

--- a/Tests/SkipBuildTests/SkipBuildTests.swift
+++ b/Tests/SkipBuildTests/SkipBuildTests.swift
@@ -153,6 +153,376 @@ final class SkipBuildTests: XCTestCase {
         XCTAssertEqual("SkipModel", pmod.dependencies.first?.moduleName)
     }
 
+    // MARK: - Meta Generate Tests
+
+    func testLocaleNormalization() {
+        XCTAssertEqual("zh-CN", MetaIndexCommand.normalizeLocale("zh-Hans"))
+        XCTAssertEqual("zh-TW", MetaIndexCommand.normalizeLocale("zh-Hant"))
+        XCTAssertEqual("zh-TW", MetaIndexCommand.normalizeLocale("zh-Hant-TW"))
+        XCTAssertEqual("zh-HK", MetaIndexCommand.normalizeLocale("zh-Hant-HK"))
+        XCTAssertEqual("ar", MetaIndexCommand.normalizeLocale("ar-SA"))
+        XCTAssertEqual("no-NO", MetaIndexCommand.normalizeLocale("nb-NO"))
+        XCTAssertEqual("iw-IL", MetaIndexCommand.normalizeLocale("he-IL"))
+        XCTAssertEqual("en-US", MetaIndexCommand.normalizeLocale("en-US"))
+        XCTAssertEqual("fr-FR", MetaIndexCommand.normalizeLocale("fr-FR"))
+        XCTAssertEqual("pt-BR", MetaIndexCommand.normalizeLocale("pt-BR"))
+        XCTAssertEqual("pt-PT", MetaIndexCommand.normalizeLocale("pt-PT"))
+        XCTAssertEqual("de-DE", MetaIndexCommand.normalizeLocale("de-DE"))
+    }
+
+    func testMetadataKeyNormalization() {
+        XCTAssertEqual("description", MetaIndexCommand.normalizeMetadataKey("full_description", platform: .android))
+        XCTAssertEqual("subtitle", MetaIndexCommand.normalizeMetadataKey("short_description", platform: .android))
+        XCTAssertEqual("title", MetaIndexCommand.normalizeMetadataKey("title", platform: .android))
+        XCTAssertEqual("releaseNotes", MetaIndexCommand.normalizeMetadataKey("release_notes", platform: .ios))
+        XCTAssertEqual("privacyURL", MetaIndexCommand.normalizeMetadataKey("privacy_url", platform: .ios))
+        XCTAssertEqual("supportURL", MetaIndexCommand.normalizeMetadataKey("support_url", platform: .ios))
+        XCTAssertEqual("subtitle", MetaIndexCommand.normalizeMetadataKey("subtitle", platform: .ios))
+    }
+
+    func testParseSkipEnv() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let envFile = tmpDir.appendingPathComponent("Skip.env")
+        try """
+        PRODUCT_NAME = TestApp
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.test
+        MARKETING_VERSION = 1.2.3
+        CURRENT_PROJECT_VERSION = 42
+        ANDROID_APPLICATION_ID = com.example.test.android
+        APPLE_APP_STORE_ID = 123456789
+        GOOGLE_PLAY_STORE_ID = com.example.test
+        """.write(to: envFile, atomically: true, encoding: .utf8)
+
+        let env = try cmd.parseSkipEnv(at: envFile)
+        XCTAssertEqual(env["PRODUCT_NAME"], "TestApp")
+        XCTAssertEqual(env["PRODUCT_BUNDLE_IDENTIFIER"], "com.example.test")
+        XCTAssertEqual(env["MARKETING_VERSION"], "1.2.3")
+        XCTAssertEqual(env["CURRENT_PROJECT_VERSION"], "42")
+        XCTAssertEqual(env["ANDROID_APPLICATION_ID"], "com.example.test.android")
+        XCTAssertEqual(env["APPLE_APP_STORE_ID"], "123456789")
+        XCTAssertEqual(env["GOOGLE_PLAY_STORE_ID"], "com.example.test")
+    }
+
+    func testParseInfoPlist() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let plistFile = tmpDir.appendingPathComponent("Info.plist")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>ITSAppUsesNonExemptEncryption</key>
+            <false/>
+            <key>NSLocationWhenInUseUsageDescription</key>
+            <string>We need your location for nearby search</string>
+            <key>NSCameraUsageDescription</key>
+            <string>We need camera access for photos</string>
+        </dict>
+        </plist>
+        """.write(to: plistFile, atomically: true, encoding: .utf8)
+
+        let info = try cmd.parseInfoPlist(at: plistFile)
+        XCTAssertEqual(info["ITSAppUsesNonExemptEncryption"] as? Bool, false)
+
+        let permissions = try cmd.extractIOSPermissions(at: plistFile)
+        XCTAssertEqual(permissions.count, 2)
+        let permKeys = permissions.map { $0["key"]! }.sorted()
+        XCTAssertEqual(permKeys, ["NSCameraUsageDescription", "NSLocationWhenInUseUsageDescription"])
+    }
+
+    func testParseAndroidManifest() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let manifestFile = tmpDir.appendingPathComponent("AndroidManifest.xml")
+        try """
+        <?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+            <!-- <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/> -->
+            <uses-permission android:name="android.permission.INTERNET" />
+            <uses-permission android:name="android.permission.CAMERA" />
+            <application
+                android:label="${PRODUCT_NAME}"
+                android:name=".AndroidAppMain">
+            </application>
+        </manifest>
+        """.write(to: manifestFile, atomically: true, encoding: .utf8)
+
+        let permissions = try cmd.extractAndroidPermissions(at: manifestFile)
+        // Should only include non-commented permissions
+        XCTAssertEqual(permissions.count, 2)
+        XCTAssertEqual(permissions[0]["name"], "android.permission.INTERNET")
+        XCTAssertEqual(permissions[1]["name"], "android.permission.CAMERA")
+
+        let meta = try cmd.parseAndroidManifest(at: manifestFile)
+        XCTAssertEqual(meta["label"] as? String, "${PRODUCT_NAME}")
+    }
+
+    func testParseFastlaneMetadata() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Create Android-style metadata structure
+        let metaDir = tmpDir.appendingPathComponent("metadata/android")
+        let enDir = metaDir.appendingPathComponent("en-US")
+        let frDir = metaDir.appendingPathComponent("fr-FR")
+        let zhDir = metaDir.appendingPathComponent("zh-Hans")
+        try FileManager.default.createDirectory(at: enDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: frDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: zhDir, withIntermediateDirectories: true)
+
+        try "My App".write(to: enDir.appendingPathComponent("title.txt"), atomically: true, encoding: .utf8)
+        try "A great app".write(to: enDir.appendingPathComponent("full_description.txt"), atomically: true, encoding: .utf8)
+        try "Great".write(to: enDir.appendingPathComponent("short_description.txt"), atomically: true, encoding: .utf8)
+
+        try "Mon App".write(to: frDir.appendingPathComponent("title.txt"), atomically: true, encoding: .utf8)
+        try "Une super app".write(to: frDir.appendingPathComponent("full_description.txt"), atomically: true, encoding: .utf8)
+
+        try "My App Chinese".write(to: zhDir.appendingPathComponent("title.txt"), atomically: true, encoding: .utf8)
+
+        let result = cmd.parseFastlaneMetadata(folder: metaDir, platform: .android)
+
+        // Check title across locales
+        XCTAssertEqual(result["title"]?["en-US"], "My App")
+        XCTAssertEqual(result["title"]?["fr-FR"], "Mon App")
+        // zh-Hans should be normalized to zh-CN
+        XCTAssertEqual(result["title"]?["zh-CN"], "My App Chinese")
+
+        // Check description (full_description → "description")
+        XCTAssertEqual(result["description"]?["en-US"], "A great app")
+        XCTAssertEqual(result["description"]?["fr-FR"], "Une super app")
+
+        // Check short description
+        XCTAssertEqual(result["subtitle"]?["en-US"], "Great")
+    }
+
+    func testParseEntitlements() throws {
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let entFile = tmpDir.appendingPathComponent("Entitlements.plist")
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>com.apple.developer.aps-environment</key>
+            <string>production</string>
+            <key>com.apple.security.app-sandbox</key>
+            <true/>
+        </dict>
+        </plist>
+        """.write(to: entFile, atomically: true, encoding: .utf8)
+
+        let entitlements = try cmd.parseEntitlements(at: entFile)
+        XCTAssertEqual(entitlements["com.apple.developer.aps-environment"] as? String, "production")
+        XCTAssertEqual(entitlements["com.apple.security.app-sandbox"] as? Bool, true)
+    }
+
+    func testMetaGenerateCatalogStructure() throws {
+        // Test that a generated catalog from a mock project has the expected structure.
+        // We can't call generateAppCatalog directly (needs parseSwiftPackage), but we
+        // can test that building iOS/Android metadata dictionaries produces correct output.
+        let cmd = MetaIndexCommand()
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Create a minimal app project structure
+        let fm = FileManager.default
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Sources/TestApp/Skip"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Sources/TestApp/Resources"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Tests/TestAppTests"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/Sources"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/TestApp.xcodeproj"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/Assets.xcassets/AccentColor.colorset"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/Assets.xcassets/AppIcon.appiconset"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/fastlane/metadata/en-US"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Darwin/fastlane/metadata/fr-FR"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Android/app/src/main/kotlin"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Android/fastlane/metadata/android/en-US"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: tmpDir.appendingPathComponent("Android/gradle/wrapper"), withIntermediateDirectories: true)
+
+        // Required files
+        try "".write(to: tmpDir.appendingPathComponent("Sources/TestApp/Skip/skip.yml"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Sources/TestApp/Resources/Localizable.xcstrings"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Darwin/Sources/Main.swift"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Darwin/TestApp.xcconfig"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Darwin/TestApp.xcodeproj/project.pbxproj"), atomically: true, encoding: .utf8)
+        try "{}".write(to: tmpDir.appendingPathComponent("Darwin/Assets.xcassets/Contents.json"), atomically: true, encoding: .utf8)
+        try "{}".write(to: tmpDir.appendingPathComponent("Darwin/Assets.xcassets/AccentColor.colorset/Contents.json"), atomically: true, encoding: .utf8)
+        try "{}".write(to: tmpDir.appendingPathComponent("Darwin/Assets.xcassets/AppIcon.appiconset/Contents.json"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Android/gradle.properties"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Android/settings.gradle.kts"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Android/app/build.gradle.kts"), atomically: true, encoding: .utf8)
+        try "".write(to: tmpDir.appendingPathComponent("Android/app/proguard-rules.pro"), atomically: true, encoding: .utf8)
+
+        // Skip.env
+        try """
+        PRODUCT_NAME = TestApp
+        PRODUCT_BUNDLE_IDENTIFIER = com.example.testapp
+        MARKETING_VERSION = 2.0.0
+        CURRENT_PROJECT_VERSION = 10
+        APPLE_APP_STORE_ID = 9876543
+        GOOGLE_PLAY_STORE_ID = com.example.testapp
+        """.write(to: tmpDir.appendingPathComponent("Skip.env"), atomically: true, encoding: .utf8)
+
+        // Info.plist with a permission
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>ITSAppUsesNonExemptEncryption</key>
+            <false/>
+            <key>NSPhotoLibraryUsageDescription</key>
+            <string>Access photos for sharing</string>
+        </dict>
+        </plist>
+        """.write(to: tmpDir.appendingPathComponent("Darwin/Info.plist"), atomically: true, encoding: .utf8)
+
+        // Entitlements
+        try """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>com.apple.developer.aps-environment</key>
+            <string>development</string>
+        </dict>
+        </plist>
+        """.write(to: tmpDir.appendingPathComponent("Darwin/Entitlements.plist"), atomically: true, encoding: .utf8)
+
+        // AndroidManifest.xml
+        try """
+        <?xml version="1.0" encoding="utf-8"?>
+        <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+            <uses-permission android:name="android.permission.INTERNET" />
+            <uses-permission android:name="android.permission.CAMERA" />
+            <application android:label="${PRODUCT_NAME}" android:name=".AndroidAppMain">
+            </application>
+        </manifest>
+        """.write(to: tmpDir.appendingPathComponent("Android/app/src/main/AndroidManifest.xml"), atomically: true, encoding: .utf8)
+
+        // iOS fastlane metadata
+        try "TestApp".write(to: tmpDir.appendingPathComponent("Darwin/fastlane/metadata/en-US/title.txt"), atomically: true, encoding: .utf8)
+        try "A test app".write(to: tmpDir.appendingPathComponent("Darwin/fastlane/metadata/en-US/description.txt"), atomically: true, encoding: .utf8)
+        try "TestApp FR".write(to: tmpDir.appendingPathComponent("Darwin/fastlane/metadata/fr-FR/title.txt"), atomically: true, encoding: .utf8)
+
+        // Android fastlane metadata
+        try "TestApp".write(to: tmpDir.appendingPathComponent("Android/fastlane/metadata/android/en-US/title.txt"), atomically: true, encoding: .utf8)
+        try "A test app for Android".write(to: tmpDir.appendingPathComponent("Android/fastlane/metadata/android/en-US/full_description.txt"), atomically: true, encoding: .utf8)
+
+        // Build the project layout (with no URL checks since this is a test)
+        let appProject = AppProjectLayout(moduleName: "TestApp", root: tmpDir, check: AppProjectLayout.noURLChecks)
+        let env = try cmd.parseSkipEnv(at: appProject.skipEnv)
+
+        // Build iOS metadata
+        let ios = try cmd.buildIOSMetadata(appProject: appProject, projectRoot: tmpDir, productName: env["PRODUCT_NAME"]!, bundleId: env["PRODUCT_BUNDLE_IDENTIFIER"]!, version: env["MARKETING_VERSION"]!, buildNumber: env["CURRENT_PROJECT_VERSION"]!, appleStoreId: env["APPLE_APP_STORE_ID"])
+
+        XCTAssertEqual(ios["bundleIdentifier"] as? String, "com.example.testapp")
+        XCTAssertEqual(ios["version"] as? String, "2.0.0")
+        XCTAssertEqual(ios["appStoreId"] as? String, "9876543")
+        XCTAssertEqual(ios["appStoreURL"] as? String, "https://apps.apple.com/app/id9876543")
+
+        // Check iOS permissions
+        let iosPerms = ios["permissions"] as? [[String: String]]
+        XCTAssertEqual(iosPerms?.count, 1)
+        XCTAssertEqual(iosPerms?.first?["key"], "NSPhotoLibraryUsageDescription")
+
+        // Check iOS entitlements
+        let entitlements = ios["entitlements"] as? [String: Any]
+        XCTAssertEqual(entitlements?["com.apple.developer.aps-environment"] as? String, "development")
+
+        // Check iOS localized metadata
+        let iosTitle = ios["title"] as? [String: String]
+        XCTAssertEqual(iosTitle?["en-US"], "TestApp")
+        XCTAssertEqual(iosTitle?["fr-FR"], "TestApp FR")
+
+        // Build Android metadata
+        let android = try cmd.buildAndroidMetadata(appProject: appProject, projectRoot: tmpDir, productName: env["PRODUCT_NAME"]!, bundleId: env["PRODUCT_BUNDLE_IDENTIFIER"]!, androidAppId: nil, version: env["MARKETING_VERSION"]!, buildNumber: env["CURRENT_PROJECT_VERSION"]!, googlePlayStoreId: env["GOOGLE_PLAY_STORE_ID"])
+
+        XCTAssertEqual(android["applicationId"] as? String, "com.example.testapp")
+        XCTAssertEqual(android["playStoreId"] as? String, "com.example.testapp")
+
+        // Check Android permissions
+        let androidPerms = android["permissions"] as? [[String: String]]
+        XCTAssertEqual(androidPerms?.count, 2)
+        XCTAssertEqual(androidPerms?[0]["name"], "android.permission.INTERNET")
+        XCTAssertEqual(androidPerms?[1]["name"], "android.permission.CAMERA")
+
+        // Check Android localized metadata
+        let androidTitle = android["title"] as? [String: String]
+        XCTAssertEqual(androidTitle?["en-US"], "TestApp")
+        let androidDesc = android["description"] as? [String: String]
+        XCTAssertEqual(androidDesc?["en-US"], "A test app for Android")
+    }
+
+    func testPNGDimensionParsing() {
+        // Construct a minimal valid PNG: 8-byte signature + IHDR chunk
+        // IHDR: 4-byte length (13) + "IHDR" + 4-byte width + 4-byte height + 5 bytes (bit depth, color type, etc.)
+        var png = Data()
+        // PNG signature
+        png.append(contentsOf: [137, 80, 78, 71, 13, 10, 26, 10] as [UInt8])
+        // IHDR chunk length: 13 bytes
+        png.append(contentsOf: [0, 0, 0, 13] as [UInt8])
+        // IHDR type
+        png.append(contentsOf: [73, 72, 68, 82] as [UInt8]) // "IHDR"
+        // Width: 320 (0x00000140)
+        png.append(contentsOf: [0, 0, 1, 64] as [UInt8])
+        // Height: 480 (0x000001E0)
+        png.append(contentsOf: [0, 0, 1, 224] as [UInt8])
+        // bit depth, color type, compression, filter, interlace
+        png.append(contentsOf: [8, 6, 0, 0, 0] as [UInt8])
+
+        let (width, height) = ImageResourceRef.parsePNGDimensions(png)
+        XCTAssertEqual(width, 320)
+        XCTAssertEqual(height, 480)
+
+        // Invalid data should return (0, 0)
+        let (w2, h2) = ImageResourceRef.parsePNGDimensions(Data([0, 1, 2]))
+        XCTAssertEqual(w2, 0)
+        XCTAssertEqual(h2, 0)
+    }
+
+    func testImageResourceRefFromPNG() throws {
+        let tmpDir = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        // Create a minimal PNG file
+        var png = Data()
+        png.append(contentsOf: [137, 80, 78, 71, 13, 10, 26, 10] as [UInt8])
+        png.append(contentsOf: [0, 0, 0, 13] as [UInt8])
+        png.append(contentsOf: [73, 72, 68, 82] as [UInt8])
+        png.append(contentsOf: [0, 0, 4, 0] as [UInt8])   // 1024
+        png.append(contentsOf: [0, 0, 4, 0] as [UInt8])   // 1024
+        png.append(contentsOf: [8, 6, 0, 0, 0] as [UInt8])
+
+        let iconFile = tmpDir.appendingPathComponent("icon.png")
+        try png.write(to: iconFile)
+
+        let ref = try XCTUnwrap(ImageResourceRef.from(pngURL: iconFile, relativeTo: tmpDir))
+        XCTAssertEqual(ref.width, 1024)
+        XCTAssertEqual(ref.height, 1024)
+        XCTAssertEqual(ref.location, "icon.png")
+        XCTAssertEqual(ref.mimeType, "image/png")
+        XCTAssertEqual(ref.size, Int64(png.count))
+        XCTAssertFalse(ref.hash.isEmpty)
+    }
+
     func testParseSwiftToolchainAPI() async throws {
         let staticLinuxSDKs = try await SwiftSDKOpenAPI.fetchSDKs(sdkName: "static")
         let staticDownloadURL = "https://download.swift.org/swift-6.2.3-release/static-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz"

--- a/Tests/SkipBuildTests/SkipBuildTests.swift
+++ b/Tests/SkipBuildTests/SkipBuildTests.swift
@@ -587,7 +587,7 @@ final class SkipBuildTests: XCTestCase {
         XCTAssertEqual(ref.location, "icon.png")
         XCTAssertEqual(ref.mimeType, "image/png")
         XCTAssertEqual(ref.size, Int64(png.count))
-        XCTAssertFalse(ref.hash.isEmpty)
+        XCTAssertEqual(ref.digest, "sha256:8e20268c0d22111a27852d29c38e49bf908ff15b2380eb24c0675b2f500ba1e6")
     }
 
     func testParseSwiftToolchainAPI() async throws {

--- a/Tests/SkipBuildTests/SkipBuildTests.swift
+++ b/Tests/SkipBuildTests/SkipBuildTests.swift
@@ -184,18 +184,65 @@ final class SkipBuildTests: XCTestCase {
     }
 
     func testLocaleNormalization() {
-        XCTAssertEqual("zh-CN", MetaIndexCommand.normalizeLocale("zh-Hans"))
-        XCTAssertEqual("zh-TW", MetaIndexCommand.normalizeLocale("zh-Hant"))
-        XCTAssertEqual("zh-TW", MetaIndexCommand.normalizeLocale("zh-Hant-TW"))
-        XCTAssertEqual("zh-HK", MetaIndexCommand.normalizeLocale("zh-Hant-HK"))
-        XCTAssertEqual("ar", MetaIndexCommand.normalizeLocale("ar-SA"))
-        XCTAssertEqual("no-NO", MetaIndexCommand.normalizeLocale("nb-NO"))
-        XCTAssertEqual("iw-IL", MetaIndexCommand.normalizeLocale("he-IL"))
-        XCTAssertEqual("en-US", MetaIndexCommand.normalizeLocale("en-US"))
-        XCTAssertEqual("fr-FR", MetaIndexCommand.normalizeLocale("fr-FR"))
-        XCTAssertEqual("pt-BR", MetaIndexCommand.normalizeLocale("pt-BR"))
-        XCTAssertEqual("pt-PT", MetaIndexCommand.normalizeLocale("pt-PT"))
-        XCTAssertEqual("de-DE", MetaIndexCommand.normalizeLocale("de-DE"))
+        // Apple codes → BCP 47 canonical
+        XCTAssertEqual("ar", MetaIndexCommand.normalizeLocale("ar-SA", convention: .apple))       // Arabic
+        XCTAssertEqual("zh-Hans", MetaIndexCommand.normalizeLocale("zh-Hans", convention: .apple)) // Chinese Simplified
+        XCTAssertEqual("zh-Hant", MetaIndexCommand.normalizeLocale("zh-Hant", convention: .apple)) // Chinese Traditional
+        XCTAssertEqual("en", MetaIndexCommand.normalizeLocale("en-US", convention: .apple))        // English (US) → default English
+        XCTAssertEqual("en-GB", MetaIndexCommand.normalizeLocale("en-GB", convention: .apple))     // English (UK) preserved
+        XCTAssertEqual("en-AU", MetaIndexCommand.normalizeLocale("en-AU", convention: .apple))     // English (AU) preserved
+        XCTAssertEqual("fr", MetaIndexCommand.normalizeLocale("fr-FR", convention: .apple))        // French (France) → French
+        XCTAssertEqual("fr-CA", MetaIndexCommand.normalizeLocale("fr-CA", convention: .apple))     // French (Canada) preserved
+        XCTAssertEqual("de", MetaIndexCommand.normalizeLocale("de-DE", convention: .apple))        // German
+        XCTAssertEqual("es", MetaIndexCommand.normalizeLocale("es-ES", convention: .apple))        // Spanish (Spain) → Spanish
+        XCTAssertEqual("es-MX", MetaIndexCommand.normalizeLocale("es-MX", convention: .apple))     // Spanish (Mexico) preserved
+        XCTAssertEqual("nl", MetaIndexCommand.normalizeLocale("nl-NL", convention: .apple))        // Dutch
+        XCTAssertEqual("pt-BR", MetaIndexCommand.normalizeLocale("pt-BR", convention: .apple))     // Portuguese (Brazil)
+        XCTAssertEqual("pt", MetaIndexCommand.normalizeLocale("pt-PT", convention: .apple))        // Portuguese (Portugal) → Portuguese
+        XCTAssertEqual("he", MetaIndexCommand.normalizeLocale("he", convention: .apple))           // Hebrew (Apple)
+        XCTAssertEqual("ja", MetaIndexCommand.normalizeLocale("ja", convention: .apple))           // Japanese (Apple)
+        XCTAssertEqual("ko", MetaIndexCommand.normalizeLocale("ko", convention: .apple))           // Korean (Apple)
+        XCTAssertEqual("no", MetaIndexCommand.normalizeLocale("no", convention: .apple))           // Norwegian (Apple)
+
+        // Google codes → BCP 47 canonical
+        XCTAssertEqual("ar", MetaIndexCommand.normalizeLocale("ar", convention: .google))           // Arabic
+        XCTAssertEqual("zh-Hans", MetaIndexCommand.normalizeLocale("zh-CN", convention: .google))   // Chinese Simplified
+        XCTAssertEqual("zh-Hant", MetaIndexCommand.normalizeLocale("zh-TW", convention: .google))   // Chinese Traditional
+        XCTAssertEqual("zh-Hant", MetaIndexCommand.normalizeLocale("zh-HK", convention: .google))   // Chinese Traditional (HK)
+        XCTAssertEqual("he", MetaIndexCommand.normalizeLocale("iw-IL", convention: .google))        // Hebrew (legacy "iw")
+        XCTAssertEqual("en", MetaIndexCommand.normalizeLocale("en-US", convention: .google))        // same for both platforms
+        XCTAssertEqual("cs", MetaIndexCommand.normalizeLocale("cs-CZ", convention: .google))        // Czech
+        XCTAssertEqual("da", MetaIndexCommand.normalizeLocale("da-DK", convention: .google))        // Danish
+        XCTAssertEqual("fi", MetaIndexCommand.normalizeLocale("fi-FI", convention: .google))        // Finnish
+        XCTAssertEqual("el", MetaIndexCommand.normalizeLocale("el-GR", convention: .google))        // Greek
+        XCTAssertEqual("hi", MetaIndexCommand.normalizeLocale("hi-IN", convention: .google))        // Hindi
+        XCTAssertEqual("hu", MetaIndexCommand.normalizeLocale("hu-HU", convention: .google))        // Hungarian
+        XCTAssertEqual("it", MetaIndexCommand.normalizeLocale("it-IT", convention: .google))        // Italian
+        XCTAssertEqual("ja", MetaIndexCommand.normalizeLocale("ja-JP", convention: .google))        // Japanese
+        XCTAssertEqual("ko", MetaIndexCommand.normalizeLocale("ko-KR", convention: .google))        // Korean
+        XCTAssertEqual("no", MetaIndexCommand.normalizeLocale("no-NO", convention: .google))        // Norwegian
+        XCTAssertEqual("pl", MetaIndexCommand.normalizeLocale("pl-PL", convention: .google))        // Polish
+        XCTAssertEqual("ru", MetaIndexCommand.normalizeLocale("ru-RU", convention: .google))        // Russian
+        XCTAssertEqual("sv", MetaIndexCommand.normalizeLocale("sv-SE", convention: .google))        // Swedish
+        XCTAssertEqual("tr", MetaIndexCommand.normalizeLocale("tr-TR", convention: .google))        // Turkish
+        XCTAssertEqual("ms", MetaIndexCommand.normalizeLocale("ms-MY", convention: .google))        // Malay
+        XCTAssertEqual("es-419", MetaIndexCommand.normalizeLocale("es-419", convention: .google))   // Spanish (LatAm) preserved
+        XCTAssertEqual("es-US", MetaIndexCommand.normalizeLocale("es-US", convention: .google))     // Spanish (US) preserved
+
+        // Already canonical codes pass through unchanged
+        XCTAssertEqual("ca", MetaIndexCommand.normalizeLocale("ca", convention: .apple))
+        XCTAssertEqual("hr", MetaIndexCommand.normalizeLocale("hr", convention: .apple))
+        XCTAssertEqual("ro", MetaIndexCommand.normalizeLocale("ro", convention: .apple))
+        XCTAssertEqual("sk", MetaIndexCommand.normalizeLocale("sk", convention: .apple))
+        XCTAssertEqual("uk", MetaIndexCommand.normalizeLocale("uk", convention: .apple))
+        XCTAssertEqual("vi", MetaIndexCommand.normalizeLocale("vi", convention: .apple))
+        XCTAssertEqual("th", MetaIndexCommand.normalizeLocale("th", convention: .apple))
+        XCTAssertEqual("hr", MetaIndexCommand.normalizeLocale("hr", convention: .google))
+        XCTAssertEqual("ro", MetaIndexCommand.normalizeLocale("ro", convention: .google))
+        XCTAssertEqual("sk", MetaIndexCommand.normalizeLocale("sk", convention: .google))
+        XCTAssertEqual("uk", MetaIndexCommand.normalizeLocale("uk", convention: .google))
+        XCTAssertEqual("vi", MetaIndexCommand.normalizeLocale("vi", convention: .google))
+        XCTAssertEqual("th", MetaIndexCommand.normalizeLocale("th", convention: .google))
     }
 
     func testMetadataKeyNormalization() {
@@ -266,7 +313,7 @@ final class SkipBuildTests: XCTestCase {
         let permKeys = permissions.compactMap { $0["key"] as? String }.sorted()
         XCTAssertEqual(permKeys, ["NSCameraUsageDescription", "NSLocationWhenInUseUsageDescription"])
         let cameraDesc = permissions.first(where: { $0["key"] as? String == "NSCameraUsageDescription" })?["description"] as? [String: String]
-        XCTAssertEqual(cameraDesc?["en-US"], "We need camera access for photos")
+        XCTAssertEqual(cameraDesc?["en"], "We need camera access for photos")
 
         // With xcstrings: translations are merged in
         let xcstringsFile = tmpDir.appendingPathComponent("InfoPlist.xcstrings")
@@ -298,9 +345,9 @@ final class SkipBuildTests: XCTestCase {
         let localizedPerms = try cmd.extractIOSPermissions(at: plistFile, xcstringsURL: xcstringsFile)
         let cameraPerm = localizedPerms.first(where: { $0["key"] as? String == "NSCameraUsageDescription" })
         let cameraDescs = cameraPerm?["description"] as? [String: String]
-        XCTAssertEqual(cameraDescs?["en-US"], "We need camera access for photos")
+        XCTAssertEqual(cameraDescs?["en"], "We need camera access for photos")
         XCTAssertEqual(cameraDescs?["fr"], "Accès caméra pour les photos")
-        XCTAssertEqual(cameraDescs?["zh-CN"], "需要相机权限来拍照")  // zh-Hans normalized to zh-CN
+        XCTAssertEqual(cameraDescs?["zh-Hans"], "需要相机权限来拍照")  // zh-Hans is canonical BCP 47
     }
 
     func testParseAndroidManifest() throws {
@@ -359,17 +406,20 @@ final class SkipBuildTests: XCTestCase {
         let result = cmd.parseFastlaneMetadata(folder: metaDir, platform: .android)
 
         // Check title across locales
-        XCTAssertEqual(result["title"]?["en-US"], "My App")
-        XCTAssertEqual(result["title"]?["fr-FR"], "Mon App")
-        // zh-Hans should be normalized to zh-CN
-        XCTAssertEqual(result["title"]?["zh-CN"], "My App Chinese")
+        let titles = result["title"] as? [String: String]
+        XCTAssertEqual(titles?["en"], "My App")
+        XCTAssertEqual(titles?["fr"], "Mon App")
+        // zh-Hans is the canonical BCP 47 code for Simplified Chinese
+        XCTAssertEqual(titles?["zh-Hans"], "My App Chinese")
 
         // Check description (full_description → "description")
-        XCTAssertEqual(result["description"]?["en-US"], "A great app")
-        XCTAssertEqual(result["description"]?["fr-FR"], "Une super app")
+        let descs = result["description"] as? [String: String]
+        XCTAssertEqual(descs?["en"], "A great app")
+        XCTAssertEqual(descs?["fr"], "Une super app")
 
         // Check short description
-        XCTAssertEqual(result["subtitle"]?["en-US"], "Great")
+        let subtitles = result["subtitle"] as? [String: String]
+        XCTAssertEqual(subtitles?["en"], "Great")
     }
 
     func testParseEntitlements() throws {
@@ -499,30 +549,36 @@ final class SkipBuildTests: XCTestCase {
 
         XCTAssertEqual(ios["bundleIdentifier"] as? String, "com.example.testapp")
         XCTAssertEqual(ios["version"] as? String, "2.0.0")
-        XCTAssertEqual(ios["appStoreId"] as? String, "9876543")
-        XCTAssertEqual(ios["appStoreURL"] as? String, "https://apps.apple.com/app/id9876543")
+        let iosChannels = ios["channels"] as? [String: Any]
+        let appleAppStore = iosChannels?["appleappstore"] as? [String: Any]
+        XCTAssertEqual(appleAppStore?["id"] as? String, "9876543")
+        XCTAssertEqual(appleAppStore?["url"] as? String, "https://apps.apple.com/app/id9876543")
 
         // Check iOS permissions
         let iosPerms = ios["permissions"] as? [[String: Any]]
         XCTAssertEqual(iosPerms?.count, 1)
         XCTAssertEqual(iosPerms?.first?["key"] as? String, "NSPhotoLibraryUsageDescription")
         let photoDesc = iosPerms?.first?["description"] as? [String: String]
-        XCTAssertEqual(photoDesc?["en-US"], "Access photos for sharing")
+        XCTAssertEqual(photoDesc?["en"], "Access photos for sharing")
 
-        // Check iOS entitlements
-        let entitlements = ios["entitlements"] as? [String: Any]
+        // Check iOS metadata (entitlements are now inside metadata dict)
+        let iosMetadata = ios["metadata"] as? [String: Any]
+        let entitlements = iosMetadata?["entitlements"] as? [String: Any]
         XCTAssertEqual(entitlements?["com.apple.developer.aps-environment"] as? String, "development")
 
         // Check iOS localized metadata
         let iosTitle = ios["title"] as? [String: String]
-        XCTAssertEqual(iosTitle?["en-US"], "TestApp")
-        XCTAssertEqual(iosTitle?["fr-FR"], "TestApp FR")
+        XCTAssertEqual(iosTitle?["en"], "TestApp")
+        XCTAssertEqual(iosTitle?["fr"], "TestApp FR")
 
         // Build Android metadata
         let android = try cmd.buildAndroidMetadata(appProject: appProject, projectRoot: tmpDir, productName: env["PRODUCT_NAME"]!, bundleId: env["PRODUCT_BUNDLE_IDENTIFIER"]!, androidAppId: nil, version: env["MARKETING_VERSION"]!, buildNumber: env["CURRENT_PROJECT_VERSION"]!, googlePlayStoreId: env["GOOGLE_PLAY_STORE_ID"])
 
         XCTAssertEqual(android["applicationId"] as? String, "com.example.testapp")
-        XCTAssertEqual(android["playStoreId"] as? String, "com.example.testapp")
+        let androidChannels = android["channels"] as? [String: Any]
+        let googlePlayStore = androidChannels?["googleplaystore"] as? [String: Any]
+        XCTAssertEqual(googlePlayStore?["id"] as? String, "com.example.testapp")
+        XCTAssertEqual(googlePlayStore?["url"] as? String, "https://play.google.com/store/apps/details?id=com.example.testapp")
 
         // Check Android permissions
         let androidPerms = android["permissions"] as? [[String: String]]
@@ -532,9 +588,9 @@ final class SkipBuildTests: XCTestCase {
 
         // Check Android localized metadata
         let androidTitle = android["title"] as? [String: String]
-        XCTAssertEqual(androidTitle?["en-US"], "TestApp")
+        XCTAssertEqual(androidTitle?["en"], "TestApp")
         let androidDesc = android["description"] as? [String: String]
-        XCTAssertEqual(androidDesc?["en-US"], "A test app for Android")
+        XCTAssertEqual(androidDesc?["en"], "A test app for Android")
     }
 
     func testPNGDimensionParsing() {

--- a/Tests/SkipBuildTests/SkipCommandTests.swift
+++ b/Tests/SkipBuildTests/SkipCommandTests.swift
@@ -429,6 +429,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  └─ Sources
         │     └─ Main.swift
         ├─ LICENSE.txt
@@ -506,6 +507,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  ├─ Sources
         │  │  └─ Main.swift
         │  └─ fastlane
@@ -640,6 +642,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  └─ Sources
         │     └─ Main.swift
         ├─ LICENSE.txt
@@ -932,6 +935,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  └─ Sources
         │     └─ Main.swift
         ├─ Package.swift
@@ -1124,6 +1128,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  └─ Sources
         │     └─ Main.swift
         ├─ Package.swift
@@ -1305,6 +1310,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  └─ Sources
         │     └─ Main.swift
         ├─ Package.swift
@@ -1417,6 +1423,7 @@ final class SkipCommandTests: XCTestCase {
         │  │     └─ xcschemes
         │  │        └─ FreeApp App.xcscheme
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  ├─ Sources
         │  │  └─ Main.swift
         │  └─ fastlane
@@ -1554,6 +1561,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  ├─ Sources
         │  │  └─ Main.swift
         │  ├─ TopModule.xcconfig
@@ -1724,6 +1732,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  ├─ M1.xcconfig
         │  ├─ M1.xcodeproj
         │  │  ├─ project.pbxproj
@@ -1851,6 +1860,7 @@ final class SkipCommandTests: XCTestCase {
         │  │  └─ Contents.json
         │  ├─ Entitlements.plist
         │  ├─ Info.plist
+        │  ├─ InfoPlist.xcstrings
         │  ├─ M1.xcconfig
         │  ├─ M1.xcodeproj
         │  │  ├─ project.pbxproj


### PR DESCRIPTION
This PR adds a `skip meta index` command that will output an `appindex.json` file, containing a manifest of the app's metadata, including the localized fastlane information, relative links to the various icons and screenshots, and, optionally, embed the sbom (added in https://github.com/skiptools/skipstone/pull/227).

We also add an `--appindex` flag to `skip export` in order to include the metadata in exported builds, as well as link the `appindex.json` into the app's primary module's Resources/ folder so the app can introspect on its own metadata at runtime.