### PR TITLE
Add `onStart` handler to AppDelegate

### DIFF
--- a/Sources/SkipBuild/SkipProject.swift
+++ b/Sources/SkipBuild/SkipProject.swift
@@ -2494,6 +2494,7 @@ private typealias AppDelegate = \(primaryModuleName)AppDelegate
 @main struct AppMain: App {
     @AppDelegateAdaptor(AppMainDelegate.self) var appDelegate
     @Environment(\\.scenePhase) private var scenePhase
+    @State private var started = false
 
     var body: some Scene {
         WindowGroup {
@@ -2502,10 +2503,15 @@ private typealias AppDelegate = \(primaryModuleName)AppDelegate
         .onChange(of: scenePhase) { oldPhase, newPhase in
             switch newPhase {
             case .active:
+                if !started {
+                    started = true
+                    AppDelegate.shared.onStart()
+                }
                 AppDelegate.shared.onResume()
             case .inactive:
                 AppDelegate.shared.onPause()
             case .background:
+                started = false
                 AppDelegate.shared.onStop()
             @unknown default:
                 print("unknown app phase: \\(newPhase)")
@@ -2621,6 +2627,10 @@ let logger: Logger = Logger(subsystem: "\(appid)", category: "\(primaryModuleNam
 
     \(skipBridge)public func onPause() {
         logger.debug("onPause")
+    }
+
+    \(skipBridge)public func onStart() {
+        logger.debug("onStart")
     }
 
     \(skipBridge)public func onStop() {
@@ -3800,8 +3810,8 @@ open class MainActivity: AppCompatActivity {
     }
 
     override fun onStart() {
-        logger.info("onStart")
         super.onStart()
+        AppDelegate.shared.onStart()
     }
 
     override fun onResume() {


### PR DESCRIPTION
On Android, `onStart` is called right before `onResume` if the app is launching, or if the app had been stopped. On iOS, we're tracking this with a state variable.

Skip Pull Request Checklist:

- [x] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [x] REQUIRED: I have tested my change locally with `swift test`
- [x] OPTIONAL: I have tested my change on an iOS simulator or device
- [x] OPTIONAL: I have tested my change on an Android emulator or device

-----

- [ ] AI was used to generate or assist with generating this PR. *Please specify below how you used AI to help you, and what steps you have taken to manually verify the changes*.

-----

