### PR TITLE
Prevent bridging for code within SKIP_MODE_FUSE blocks

### DIFF
--- a/Sources/SkipBuild/Commands/SkipstoneCommand.swift
+++ b/Sources/SkipBuild/Commands/SkipstoneCommand.swift
@@ -417,7 +417,17 @@ struct SkipstoneCommand: BuildPluginOptionsCommand, StreamingCommand {
                 transpileFiles.append(sourceFile)
             }
         }
-        let transpiler = Transpiler(packageName: packageName, transpileFiles: transpileFiles.map(Source.FilePath.init(path:)), bridgeFiles: swiftFiles.map(Source.FilePath.init(path:)), autoBridge: autoBridge, isBridgeGatherEnabled: dynamicRoot != nil, codebaseInfo: codebaseInfo, preprocessorSymbols: Set(inputOptions.symbols), transformers: transformers)
+        // Implicitly define SKIP_MODE_FUSE in Fuse bridge mode and SKIP_MODE_LITE otherwise so that
+        // user code can gate types out of bridging with `#if !SKIP_MODE_FUSE` (or in Lite-only code
+        // with `#if SKIP_MODE_LITE`). These mirror the convention used in app Package.swift files
+        // that pass `-DSKIP_MODE_FUSE`/`-DSKIP_MODE_LITE` to the Swift compiler.
+        var preprocessorSymbols = Set(inputOptions.symbols)
+        if skipstoneOptions.skipBridgeOutput != nil {
+            preprocessorSymbols.insert("SKIP_MODE_FUSE")
+        } else {
+            preprocessorSymbols.insert("SKIP_MODE_LITE")
+        }
+        let transpiler = Transpiler(packageName: packageName, transpileFiles: transpileFiles.map(Source.FilePath.init(path:)), bridgeFiles: swiftFiles.map(Source.FilePath.init(path:)), autoBridge: autoBridge, isBridgeGatherEnabled: dynamicRoot != nil, codebaseInfo: codebaseInfo, preprocessorSymbols: preprocessorSymbols, transformers: transformers)
 
         try await transpiler.transpile(handler: handleTranspilation)
         try saveCodebaseInfo() // save out the ModuleName.skipcode.json

--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeToKotlinVisitor.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeToKotlinVisitor.swift
@@ -889,6 +889,9 @@ final class KotlinBridgeToKotlinVisitor {
     }
 
     @discardableResult private func update(_ interfaceDeclaration: KotlinInterfaceDeclaration) -> Bool {
+        guard !interfaceDeclaration.attributes.isNoBridge else {
+            return false
+        }
         guard interfaceDeclaration.checkBridgable(direction: .toKotlin, options: options, translator: translator) else {
             return false
         }
@@ -945,6 +948,9 @@ final class KotlinBridgeToKotlinVisitor {
 
     @discardableResult private func update(_ classDeclaration: KotlinClassDeclaration) -> Bool {
         guard !classDeclaration.isGenerated else {
+            return false
+        }
+        guard !classDeclaration.attributes.isNoBridge else {
             return false
         }
         guard classDeclaration.checkBridgable(direction: .toKotlin, options: options, translator: translator) else {

--- a/Sources/SkipSyntax/StatementTypes.swift
+++ b/Sources/SkipSyntax/StatementTypes.swift
@@ -1542,7 +1542,7 @@ class TypeDeclaration: Statement {
         var attributes = Attributes.for(syntax: classDecl.attributes, in: syntaxTree)
         attributes.addDirectives(from: extras, in: syntaxTree)
         guard decodeLevel(attributes: attributes, visibility: modifiers.visibility, context: context, in: syntaxTree) != .none else {
-            if syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, attributes.contains(.observable) {
+            if !attributes.isNoBridge, syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, attributes.contains(.observable) {
                 return UnbridgedMemberDeclaration(member: .observableType(name), syntax: classDecl, extras: extras, in: syntaxTree)
             }
             return nil
@@ -1567,8 +1567,8 @@ class TypeDeclaration: Statement {
         var decodeLevel = self.decodeLevel(attributes: attributes, visibility: modifiers.visibility, context: context, in: syntaxTree)
         var decodeFlags: DecodeFlags = []
         if decodeLevel == .none {
-            // We need to decode native views for adapting to SkipSwiftUI
-            if syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, let inheritsView = inherits.first(where: { isSwiftUIType($0) }) {
+            // We need to decode native views for adapting to SkipSwiftUI, unless explicitly opted out
+            if !attributes.isNoBridge, syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, let inheritsView = inherits.first(where: { isSwiftUIType($0) }) {
                 decodeLevel = .api
                 decodeFlags.insert(.swiftUIState)
                 // We don't care about other protocols
@@ -1621,8 +1621,8 @@ class TypeDeclaration: Statement {
         var decodeLevel = self.decodeLevel(attributes: attributes, visibility: modifiers.visibility, context: context, in: syntaxTree)
         var decodeFlags: DecodeFlags = []
         if decodeLevel == .none {
-            // We need to decode native views for adapting to SkipSwiftUI
-            if syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, let inheritsView = inherits.first(where: { isSwiftUIType($0) }) {
+            // We need to decode native views for adapting to SkipSwiftUI, unless explicitly opted out
+            if !attributes.isNoBridge, syntaxTree.isBridgeFile, syntaxTree.autoBridge != .none, let inheritsView = inherits.first(where: { isSwiftUIType($0) }) {
                 decodeLevel = .api
                 decodeFlags.insert(.swiftUIState)
                 // We don't care about other protocols

--- a/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
@@ -7471,6 +7471,37 @@ final class BridgeToKotlinTests: XCTestCase {
         """, transformers: transformers)
     }
 
+    func testNoBridgeView() async throws {
+        try await check(swiftBridge: """
+        import SkipFuseUI
+        // SKIP @nobridge
+        struct V: View {
+            @State var count = 1
+            var body: some View {
+                Text("Hello")
+            }
+        }
+        """, kotlin: """
+        """, swiftBridgeSupport: """
+        """, transformers: transformers)
+    }
+
+    func testNoBridgeInFuseModeBlock() async throws {
+        try await check(swiftBridge: """
+        import SkipFuseUI
+        #if !SKIP_MODE_FUSE
+        struct V: View {
+            @State var count = 1
+            var body: some View {
+                Text("Hello")
+            }
+        }
+        #endif
+        """, kotlin: """
+        """, swiftBridgeSupport: """
+        """, preprocessorSymbols: ["SKIP_MODE_FUSE"], transformers: transformers)
+    }
+
     func testGenericView() async throws {
         try await check(swiftBridge: """
         import SkipFuseUI

--- a/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
+++ b/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
@@ -32,7 +32,7 @@ extension XCTestCase {
     ///   - swiftBridgeSupports: multiple expected bridging swift outputs
     ///   - file: the file of the call site, expected to be `#file`
     ///   - line: the line of the call site, expected to be `#line`
-    public func check(expectFailure: Bool = false, expectMessages: Bool = false, compiler: String? = ProcessInfo.processInfo.environment["KOTLINC"], dependentModules: [CodebaseInfo.ModuleExport] = [], supportingSwift: String? = nil, swift: StaticString? = nil, swiftCode: (() throws -> String?)? = nil, swiftBridge: String? = nil, kotlin: String? = nil, kotlins: [String] = [], fixup fixupKotlinBlock: ((String) -> (String)) = { $0 }, kotlinPackageSupport: String? = nil, swiftBridgeSupport: String? = nil, swiftBridgeSupports: [String] = [], bridgeDecodeLevel: DecodeLevel = .api, transformers: [KotlinTransformer] = builtinKotlinTransformers(), file: StaticString = #file, line: UInt = #line) async throws {
+    public func check(expectFailure: Bool = false, expectMessages: Bool = false, compiler: String? = ProcessInfo.processInfo.environment["KOTLINC"], dependentModules: [CodebaseInfo.ModuleExport] = [], supportingSwift: String? = nil, swift: StaticString? = nil, swiftCode: (() throws -> String?)? = nil, swiftBridge: String? = nil, kotlin: String? = nil, kotlins: [String] = [], fixup fixupKotlinBlock: ((String) -> (String)) = { $0 }, kotlinPackageSupport: String? = nil, swiftBridgeSupport: String? = nil, swiftBridgeSupports: [String] = [], bridgeDecodeLevel: DecodeLevel = .api, preprocessorSymbols: Set<String> = [], transformers: [KotlinTransformer] = builtinKotlinTransformers(), file: StaticString = #file, line: UInt = #line) async throws {
 
         func fixup(code: String) -> String {
             var code = fixupKotlinBlock(code)
@@ -102,7 +102,7 @@ extension XCTestCase {
         }
         let codebaseInfo = CodebaseInfo()
         codebaseInfo.dependentModules = dependentModules
-        let tp = Transpiler(transpileFiles: srcFiles, bridgeFiles: bridgeFiles, autoBridge: bridgeDecodeLevel == .api ? .public : .none, isBridgeGatherEnabled: bridgeDecodeLevel == .full, codebaseInfo: codebaseInfo, transformers: transformers)
+        let tp = Transpiler(transpileFiles: srcFiles, bridgeFiles: bridgeFiles, autoBridge: bridgeDecodeLevel == .api ? .public : .none, isBridgeGatherEnabled: bridgeDecodeLevel == .full, codebaseInfo: codebaseInfo, preprocessorSymbols: preprocessorSymbols, transformers: transformers)
         var transpilations: [Transpilation] = []
         try await tp.transpile { transpilations.append($0) }
         guard !transpilations.isEmpty else {


### PR DESCRIPTION
This PR enables the `SKIP_MODE_FUSE` and `SKIP_MODE_LITE` compiler definitions that can conditionally gate code on whether Skip is building in Skip Fuse or Skip Lite mode. This is useful for an app or framework that can be conditionally compiled in either Skip Fuse or Skip Lite modes (e.g., https://github.com/skiptools/skipapp-showcase/pull/100)