### PR TITLE
Add merge append/prepend option to skip.yml blocks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", from: "0.7.3"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
-        .package(url: "https://github.com/marcprux/universal.git", from: "5.3.0"),
+        .package(url: "https://github.com/marcprux/universal.git", from: "6.0.0"),
         .package(url: "https://github.com/marcprux/ELFKit.git", from: "0.2.1"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", from: "0.7.3"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
-        .package(url: "https://github.com/marcprux/universal.git", from: "6.0.0"),
+        .package(url: "https://github.com/marcprux/universal.git", from: "5.0.0"),
         .package(url: "https://github.com/marcprux/ELFKit.git", from: "0.2.1"),
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "602.0.0"),
         .package(url: "https://github.com/swiftlang/swift-tools-support-core.git", from: "0.7.3"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.7.0"),
-        .package(url: "https://github.com/marcprux/universal.git", from: "5.0.0"),
+        .package(url: "https://github.com/marcprux/universal.git", from: "5.3.0"),
         .package(url: "https://github.com/marcprux/ELFKit.git", from: "0.2.1"),
     ],
     targets: [

--- a/Sources/SkipBuild/GradleProject.swift
+++ b/Sources/SkipBuild/GradleProject.swift
@@ -28,6 +28,20 @@ struct GradleBlock : Equatable, Codable {
     var export: Bool?
     /// A set of contents to remove if they are set
     var remove: Set<String>?
+    /// How this block's `contents` should be combined when merged with another block of the
+    /// same name. Defaults to `.append` (later-encountered contents are appended after earlier
+    /// ones). Set to `.prepend` for blocks whose underlying DSL uses *first-call-wins*
+    /// semantics — most notably `versionCatalogs.create("libs") { version(...); library(...) }` —
+    /// so that a leaf module's overrides (which are merged in later) end up emitted *before* the
+    /// dependent module's defaults and therefore take precedence. The flag is sticky: once any
+    /// side of a merge requests `.prepend`, the merged result keeps that mode for subsequent
+    /// merges in the chain.
+    var merge: MergeMode?
+
+    enum MergeMode : String, Equatable, Codable {
+        case append
+        case prepend
+    }
 
     typealias BlockOrCommand = Either<String>.Or<GradleBlock>
 
@@ -114,7 +128,18 @@ struct GradleBlock : Equatable, Codable {
                 if let index = mergedBlocks.firstIndex(where: { $0.0 == block.block }) {
                     if var fromBlock = mergedBlocks[index].boc.infer() as GradleBlock? {
                         // clear any contents we have explicitly removed from a later block
-                        fromBlock.contents = (fromBlock.filteredContents(remove: block.remove)) + (block.filteredContents(remove: block.remove))
+                        let fromContents = fromBlock.filteredContents(remove: block.remove)
+                        let newContents = block.filteredContents(remove: block.remove)
+                        // honor `merge: prepend` on either side so first-wins DSLs (e.g. version
+                        // catalogs) get the leaf module's overrides emitted before the dependent's
+                        // defaults; the flag is sticky across the merge chain
+                        let shouldPrepend = fromBlock.merge == .prepend || block.merge == .prepend
+                        if shouldPrepend {
+                            fromBlock.contents = newContents + fromContents
+                            fromBlock.merge = .prepend
+                        } else {
+                            fromBlock.contents = fromContents + newContents
+                        }
                         mergedBlocks[index].boc = .init(fromBlock)
                     }
                 } else {

--- a/Tests/SkipBuildTests/SkipConfigTests.swift
+++ b/Tests/SkipBuildTests/SkipConfigTests.swift
@@ -220,6 +220,208 @@ final class SkipConfigTests: XCTestCase {
 
     }
 
+    // MARK: - merge: prepend (leaf-wins for first-call-wins DSLs)
+
+    /// Sanity check that the default merge mode (no `merge:` field) keeps the existing
+    /// append behavior, where the second YAML document's contents are emitted after the
+    /// first's. This is a regression guard for the targeted-prepend change.
+    func testMergedGradleDefaultAppend() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                contents:
+                  - 'version("android-sdk-min", "28")'
+        ---
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                contents:
+                  - 'version("android-sdk-min", "26")'
+        """, gradle: """
+        versionCatalogs {
+            create("libs") {
+                version("android-sdk-min", "28")
+                version("android-sdk-min", "26")
+            }
+        }
+        """)
+    }
+
+    /// With `merge: 'prepend'` declared on the dependent-side block, the leaf module's
+    /// later-merged entries are emitted *before* the dependent's earlier entries — so the
+    /// leaf's `version("android-sdk-min", "26")` appears first in the generated DSL and
+    /// wins in Gradle's first-call-wins version catalog.
+    func testMergedGradlePrependOnDependent() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                merge: 'prepend'
+                contents:
+                  - 'version("android-sdk-min", "28")'
+        ---
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                contents:
+                  - 'version("android-sdk-min", "26")'
+        """, gradle: """
+        versionCatalogs {
+            create("libs") {
+                version("android-sdk-min", "26")
+                version("android-sdk-min", "28")
+            }
+        }
+        """)
+    }
+
+    /// Declaring `merge: 'prepend'` on the leaf-side block produces the same result as
+    /// declaring it on the dependent side. Either side opting into prepend is enough.
+    func testMergedGradlePrependOnLeaf() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                contents:
+                  - 'version("android-sdk-min", "28")'
+        ---
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                merge: 'prepend'
+                contents:
+                  - 'version("android-sdk-min", "26")'
+        """, gradle: """
+        versionCatalogs {
+            create("libs") {
+                version("android-sdk-min", "26")
+                version("android-sdk-min", "28")
+            }
+        }
+        """)
+    }
+
+    /// The `merge: prepend` flag is scoped to the block that declares it. A sibling
+    /// `dependencies` block — which uses last-wins / order-irrelevant DSL semantics —
+    /// must keep its default append behavior so leaf overrides of property assignments
+    /// (like `minSdk = …`) and dependency declarations continue to work.
+    func testMergedGradlePrependDoesNotAffectSiblings() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                merge: 'prepend'
+                contents:
+                  - 'version("android-sdk-min", "28")'
+          - block: 'dependencies'
+            contents:
+              - 'implementation("dep-from-base")'
+          - block: 'android'
+            contents:
+              - block: 'defaultConfig'
+                contents:
+                  - 'minSdk = 31'
+        ---
+        contents:
+          - block: 'versionCatalogs'
+            contents:
+              - block: 'create("libs")'
+                contents:
+                  - 'version("android-sdk-min", "26")'
+          - block: 'dependencies'
+            contents:
+              - 'implementation("dep-from-leaf")'
+          - block: 'android'
+            contents:
+              - block: 'defaultConfig'
+                contents:
+                  - 'minSdk = 26'
+        """, gradle: """
+        versionCatalogs {
+            create("libs") {
+                version("android-sdk-min", "26")
+                version("android-sdk-min", "28")
+            }
+        }
+
+        dependencies {
+            implementation("dep-from-base")
+            implementation("dep-from-leaf")
+        }
+
+        android {
+            defaultConfig {
+                minSdk = 31
+                minSdk = 26
+            }
+        }
+        """)
+    }
+
+    /// `merge: prepend` composes cleanly with `remove:` — the leaf module's explicit removal
+    /// still strips the targeted dependent-side line, and the surviving entries are emitted
+    /// with the leaf's contributions prepended ahead of the dependent's defaults.
+    func testMergedGradlePrependRespectsRemove() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'create("libs")'
+            merge: 'prepend'
+            contents:
+              - 'version("android-sdk-min", "28")'
+              - 'version("android-sdk-compile", "36")'
+        ---
+        contents:
+          - block: 'create("libs")'
+            remove: ['version("android-sdk-compile", "36")']
+            contents:
+              - 'version("android-sdk-compile", "35")'
+        """, gradle: """
+        create("libs") {
+            version("android-sdk-compile", "35")
+            version("android-sdk-min", "28")
+        }
+        """)
+    }
+
+    /// `merge: prepend` is sticky across a chain of three or more layered merges. Even when
+    /// only the deepest dependent declares `merge: 'prepend'`, the leaf's entries still end
+    /// up first, with each intervening module's entries inserted ahead of the modules deeper
+    /// than it. This models a realistic skip-unit → skip-foundation → skip-ui → app chain
+    /// where only skip-unit's `create("libs")` carries the flag.
+    func testMergedGradlePrependStickyAcrossChain() throws {
+        try expectGradle(yaml: """
+        contents:
+          - block: 'create("libs")'
+            merge: 'prepend'
+            contents:
+              - 'version("v", "from-deepest")'
+        ---
+        contents:
+          - block: 'create("libs")'
+            contents:
+              - 'version("v", "from-middle")'
+        ---
+        contents:
+          - block: 'create("libs")'
+            contents:
+              - 'version("v", "from-leaf")'
+        """, gradle: """
+        create("libs") {
+            version("v", "from-leaf")
+            version("v", "from-middle")
+            version("v", "from-deepest")
+        }
+        """)
+    }
+
 #if canImport(SkipDriveExternal)
     /// Verify detection and `--fix` removal of AGP-incompatible settings in an app's build.gradle.kts.
     func testAppBuildGradleAGPIssues() throws {


### PR DESCRIPTION
Adds a `merge` mode to `skip.yml` blocks that can be set to `append` (the legacy default) or `prepend`. This controls the order of how the blocks are merged when the resulting `build.gradle.kts` or `settings.gradle.kts` is assembled. Facilitates https://github.com/skiptools/skip-unit/pull/20 and helps address issues like https://github.com/skiptools/skip/issues/474#issuecomment-4064887273