### PR TITLE
Compose statement-level View operators (e.g. Text + Text)

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinExpressionTypes.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinExpressionTypes.swift
@@ -194,6 +194,9 @@ final class KotlinBinaryOperator: KotlinExpression, KotlinSingleStatementVetoing
     var lhs: KotlinExpression
     var rhs: KotlinExpression
     var mayBeSharedMutableStruct = false
+    /// The inferred result type of the operator expression, used e.g. to decide whether a statement-level
+    /// operator that produces a View (such as `Text + Text`) needs a Compose tail call.
+    var inferredType: TypeSignature = .none
 
     static func translate(expression: BinaryOperator, translator: KotlinTranslator) -> KotlinExpression {
         // Special case when assigning to _
@@ -209,6 +212,7 @@ final class KotlinBinaryOperator: KotlinExpression, KotlinSingleStatementVetoing
 
         let kexpression = KotlinBinaryOperator(expression: expression, lhs: klhs, rhs: krhs)
         kexpression.mayBeSharedMutableStruct = expression.inferredType.kotlinMayBeSharedMutableStruct(codebaseInfo: translator.codebaseInfo)
+        kexpression.inferredType = expression.inferredType.resolvingSelf(in: expression)
 
         switch expression.op.symbol {
         case "<<=", ">>=", "&=", "|=", "^=", "~=":

--- a/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinSwiftUITransformer.swift
@@ -720,6 +720,22 @@ private final class TranslateVisitor {
                 } else {
                     return .recurse(nil)
                 }
+            } else if let binaryOperator = node as? KotlinBinaryOperator {
+                var parent = node.parent
+                if parent is KotlinSRef {
+                    parent = parent?.parent
+                }
+                // A statement-level operator expression that evaluates to a View — most notably
+                // `Text + Text` concatenation — is built into the TupleView like any other view and
+                // must get a Compose tail call. Wrap it in parentheses so `.Compose` applies to the
+                // whole operator result rather than binding to its right-hand operand.
+                if let expressionStatement = parent as? KotlinExpressionStatement, !isInAssignmentExpression(expressionStatement, in: codeBlock),
+                    isSwiftUIType(named: "View", type: binaryOperator.inferredType, codebaseInfo: translator.codebaseInfo) {
+                    addComposeTailCall(to: KotlinParenthesized(content: binaryOperator), statement: expressionStatement)
+                    return .skip
+                } else {
+                    return .recurse(nil)
+                }
             } else {
                 return .recurse(nil)
             }

--- a/Tests/SkipSyntaxTests/SwiftUITests.swift
+++ b/Tests/SkipSyntaxTests/SwiftUITests.swift
@@ -2884,4 +2884,46 @@ final class SwiftUITests: XCTestCase {
         }
         """)
     }
+
+    func testViewProducingOperatorTailCall() async throws {
+        // A statement-level operator expression that evaluates to a View (e.g. `Text + Text`
+        // concatenation) must get a Compose tail call, wrapped in parentheses so `.Compose`
+        // applies to the whole operator result rather than its right-hand operand.
+        let supportingSwift = baseSupportingSwift + """
+        extension Text {
+            // SKIP DECLARE: operator fun plus(other: Text): Text
+            func plus(other: Text) -> Text {
+            }
+        }
+        """
+
+        try await check(supportingSwift: supportingSwift, swift: """
+        import SwiftUI
+        func f() {
+            VStack {
+                Text("a") + Text("b")
+            }
+        }
+        """, kotlin: """
+        import androidx.compose.runtime.Composable
+        import androidx.compose.runtime.getValue
+        import androidx.compose.runtime.mutableStateOf
+        import androidx.compose.runtime.remember
+        import androidx.compose.runtime.saveable.Saver
+        import androidx.compose.runtime.saveable.rememberSaveable
+        import androidx.compose.runtime.setValue
+
+        import skip.ui.*
+        import skip.foundation.*
+        import skip.model.*
+        internal fun f() {
+            VStack { ->
+                ComposeBuilder { composectx: ComposeContext ->
+                    (Text("a") + Text("b")).Compose(composectx)
+                    ComposeResult.ok
+                }
+            }
+        }
+        """)
+    }
 }


### PR DESCRIPTION
## What

A statement-level operator expression that evaluates to a `View` — most notably `Text + Text` concatenation — was built into the view tree but **never composed**.

`translateViewBuilder` only appended a `.Compose(composectx)` tail call to `APICallExpression` statements. A bare `Text("a") + Text("b")` is an infix-operator (`SequenceExpr`) statement, so neither the operator nor its operands (whose parent is the operator, not the statement) ever got the tail call. The concatenation `Text` was constructed and discarded — no Compose node, zero size. Wrapping it in `.frame(...)` "fixed" it only because the outer `.frame(...)` call *is* an `APICallExpression` that gets composed.

## How

- `KotlinBinaryOperator` now carries its `inferredType` (set in `translate` from the Swift expression's inferred type).
- `translateViewBuilder` adds a tail call for statement-level `KotlinBinaryOperator`s whose result `isSwiftUIType("View", ...)` (and which aren't an assignment), wrapping the operator in `KotlinParenthesized` so `.Compose` applies to the whole result rather than binding to the right-hand operand:

```kotlin
(Text("a") + Text("b")).Compose(composectx)
```

The View-type gate means non-View operators (`Int + Int`, `String + String`, …) are unaffected.

## Testing

- `swift test` — added `SwiftUITests.testViewProducingOperatorTailCall`; full `SkipSyntaxTests` suite green (834 tests, 0 failures).
- Verified end-to-end on an Android emulator (Skip Lite) via the Showcase "Text Concatenation" playground: bare, unconstrained `Text + Text` (per-run color, weight, italic, monospaced, mixed sizes, decorations, gradient, multi-line wrapping) all render.

## Why this is the right layer

This is the **Skip Lite (transpiled)** fix. It unblocks the bare/unconstrained `Text + Text` path used by:
- skiptools/skip-ui#453 — the SkipUI `+` operator + `AnnotatedString` renderer.
- skiptools/skipapp-showcase#109 — the "Text Concatenation" playground (Lite mode).

skiptools/skip-fuse-ui#118 is the SkipFuse counterpart of the same feature; SkipFuse compiles Swift natively (no `translateViewBuilder` pass) and is **not** affected by this change. The missing tail call was the sole reason a bare concatenation collapsed to zero size in transpiled apps.

---

- [x] AI was used to assist with this PR. The root cause was diagnosed by inspecting transpiled Kotlin output (operator statements lacked `.Compose`), the fix and test were authored against the existing `translateViewBuilder` logic, and verified with the full `SkipSyntaxTests` suite plus on-device rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)