### PR TITLE
Propagate `@_exported import` declarations through transpiled module imports

### DIFF
--- a/Sources/SkipSyntax/CodebaseInfo.swift
+++ b/Sources/SkipSyntax/CodebaseInfo.swift
@@ -24,6 +24,12 @@ public final class CodebaseInfo {
         }
     }
 
+    /// Names of modules this codebase re-exports via `@_exported import` declarations.
+    ///
+    /// When another module depends on this one, the transpiler will additionally emit imports
+    /// for these modules so that names re-exported in Swift remain visible in Kotlin.
+    public internal(set) var exportedModuleNames: [String] = []
+
     /// Map between a Swift module and the equivalent Skip module(s).
     ///
     /// When a Swift module transitively imports other modules - e.g.`SwiftUI` imports `Foundation` - put the corresponding Skip module first
@@ -62,6 +68,11 @@ public final class CodebaseInfo {
     func gather(from syntaxTree: SyntaxTree) {
         assert(!isInUse)
         let importedModuleNames = syntaxTree.root.statements.importedModulePaths.compactMap(\.moduleName)
+        for exportedModuleName in syntaxTree.root.statements.exportedImportedModulePaths.compactMap(\.moduleName) {
+            if !exportedModuleNames.contains(exportedModuleName) {
+                exportedModuleNames.append(exportedModuleName)
+            }
+        }
         var needsVariableTypeInference = false
         for statement in syntaxTree.root.statements {
             switch statement.type {
@@ -125,7 +136,39 @@ public final class CodebaseInfo {
 
     private func context(importedModuleNames: [String], sourceFile: Source.FilePath?, cache: ContextCache) -> Context {
         let mappedModuleNames = importedModuleNames.flatMap { Self.moduleNameMap[$0] ?? [$0] }
-        return Context(global: self, importedModuleNames: Set(mappedModuleNames), sourceFile: sourceFile, cache: cache)
+        let expandedModuleNames = expandWithExportedImports(in: mappedModuleNames)
+        return Context(global: self, importedModuleNames: expandedModuleNames, sourceFile: sourceFile, cache: cache)
+    }
+
+    /// Expand the given module names to include modules they transitively re-export via `@_exported import`.
+    ///
+    /// When a file imports a module that re-exports others, the imported names must be visible during type
+    /// inference as if those modules were imported directly.
+    private func expandWithExportedImports(in moduleNames: [String]) -> Set<String> {
+        var result = Set(moduleNames)
+        var queue = Array(moduleNames)
+        // Build a name -> exports map, including the current module so source files that import it pick up its re-exports
+        var exportsByModule: [String: [String]] = [:]
+        for dependentModule in dependentModules where !dependentModule.exportedModuleNames.isEmpty {
+            if let name = dependentModule.moduleName {
+                exportsByModule[name] = dependentModule.exportedModuleNames
+            }
+        }
+        if let name = moduleName, !exportedModuleNames.isEmpty {
+            exportsByModule[name] = exportedModuleNames
+        }
+        while let next = queue.popLast() {
+            guard let exported = exportsByModule[next] else { continue }
+            for exportedName in exported {
+                // Re-exported names may themselves be Swift framework names that map to Skip modules
+                for mapped in Self.moduleNameMap[exportedName] ?? [exportedName] {
+                    if result.insert(mapped).inserted {
+                        queue.append(mapped)
+                    }
+                }
+            }
+        }
+        return result
     }
 
     /// The items for the given name.
@@ -1392,6 +1435,12 @@ public final class CodebaseInfo {
         public let moduleName: String?
         public let packageName: String?
 
+        /// Names of modules this module re-exports via `@_exported import`.
+        ///
+        /// Decoded as an optional field for backwards compatibility with `skipcode.json`
+        /// produced by older versions of skipstone that did not record this information.
+        public let exportedModuleNames: [String]
+
         // Default visibility for testing
         var rootTypes: [TypeInfo] = []
         var rootTypealiases: [TypealiasInfo] = []
@@ -1412,24 +1461,56 @@ public final class CodebaseInfo {
             case rootFunctions = "f"
             case rootExtensions = "e"
             case sourceFileTable = "stable"
+            case exportedModuleNames = "x"
         }
 
         public init(of codebaseInfo: CodebaseInfo) {
             self.moduleName = codebaseInfo.moduleName
             self.packageName = codebaseInfo.kotlin?.packageName
+            self.exportedModuleNames = codebaseInfo.exportedModuleNames
 
             // We want to always produce the same encoded output for the same input, because new output from one module might be a signal
             // that modules depending on it have to re-transpile. Sort for stability. API within a file will always have been added in the
             // same order, so we only need to sort by file
             let sortBy: (CodebaseInfoItem, CodebaseInfoItem) -> Bool = { ($0.sourceFile?.path ?? "") < ($1.sourceFile?.path ?? "") }
             let filter: (CodebaseInfoItem) -> Bool = { $0.modifiers.visibility == .public || $0.modifiers.visibility == .open || $0.declarationType == .extensionDeclaration }
-            
+
             // Sort types before applying `export` so that the source file table that export builds is in stable order
             self.rootTypes = codebaseInfo.rootTypes.sorted(by: sortBy).compactMap { export(typeInfo: $0, filter: filter) }
             self.rootTypealiases = codebaseInfo.rootTypealiases.sorted(by: sortBy).filter(filter).map { replaceSourceFile(for: $0) }
             self.rootVariables = codebaseInfo.rootVariables.sorted(by: sortBy).filter(filter).map { replaceSourceFile(for: $0) }
             self.rootFunctions = codebaseInfo.rootFunctions.sorted(by: sortBy).filter(filter).map { replaceSourceFile(for: $0) }
             self.rootExtensions = codebaseInfo.rootExtensions.sorted(by: sortBy).compactMap { export(typeInfo: $0, filter: filter) }
+        }
+
+        public required init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.moduleName = try container.decodeIfPresent(String.self, forKey: .moduleName)
+            self.packageName = try container.decodeIfPresent(String.self, forKey: .packageName)
+            // Backwards-compatible: older skipcode.json files predate `exportedModuleNames` and omit the key
+            self.exportedModuleNames = try container.decodeIfPresent([String].self, forKey: .exportedModuleNames) ?? []
+            self.rootTypes = try container.decodeIfPresent([TypeInfo].self, forKey: .rootTypes) ?? []
+            self.rootTypealiases = try container.decodeIfPresent([TypealiasInfo].self, forKey: .rootTypealiases) ?? []
+            self.rootVariables = try container.decodeIfPresent([VariableInfo].self, forKey: .rootVariables) ?? []
+            self.rootFunctions = try container.decodeIfPresent([FunctionInfo].self, forKey: .rootFunctions) ?? []
+            self.rootExtensions = try container.decodeIfPresent([TypeInfo].self, forKey: .rootExtensions) ?? []
+            self.sourceFileTable = try container.decodeIfPresent([String].self, forKey: .sourceFileTable) ?? []
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfPresent(moduleName, forKey: .moduleName)
+            try container.encodeIfPresent(packageName, forKey: .packageName)
+            try container.encode(rootTypes, forKey: .rootTypes)
+            try container.encode(rootTypealiases, forKey: .rootTypealiases)
+            try container.encode(rootVariables, forKey: .rootVariables)
+            try container.encode(rootFunctions, forKey: .rootFunctions)
+            try container.encode(rootExtensions, forKey: .rootExtensions)
+            try container.encode(sourceFileTable, forKey: .sourceFileTable)
+            // Omit the key entirely when empty to keep encoded output identical to older skipstone for modules without `@_exported` imports
+            if !exportedModuleNames.isEmpty {
+                try container.encode(exportedModuleNames, forKey: .exportedModuleNames)
+            }
         }
 
         private func export(typeInfo: TypeInfo, filter: (CodebaseInfoItem) -> Bool) -> TypeInfo? {

--- a/Sources/SkipSyntax/CodebaseInfo.swift
+++ b/Sources/SkipSyntax/CodebaseInfo.swift
@@ -69,6 +69,12 @@ public final class CodebaseInfo {
         assert(!isInUse)
         let importedModuleNames = syntaxTree.root.statements.importedModulePaths.compactMap(\.moduleName)
         for exportedModuleName in syntaxTree.root.statements.exportedImportedModulePaths.compactMap(\.moduleName) {
+            // Only record `@_exported` targets that are themselves Skip modules — i.e. ones we either have
+            // a `ModuleExport` for (transpiled by Skip in this build), or that map onto a Skip module via
+            // the built-in framework name table. Native-only Swift modules (e.g. `SwiftJNI`) must not be
+            // propagated, since the transpiler would otherwise emit a Kotlin import for a package that
+            // does not exist on the JVM side.
+            guard isSkipModuleName(exportedModuleName) else { continue }
             if !exportedModuleNames.contains(exportedModuleName) {
                 exportedModuleNames.append(exportedModuleName)
             }
@@ -138,6 +144,17 @@ public final class CodebaseInfo {
         let mappedModuleNames = importedModuleNames.flatMap { Self.moduleNameMap[$0] ?? [$0] }
         let expandedModuleNames = expandWithExportedImports(in: mappedModuleNames)
         return Context(global: self, importedModuleNames: expandedModuleNames, sourceFile: sourceFile, cache: cache)
+    }
+
+    /// Whether the given Swift module name refers to a Skip-transpiled module — either one transpiled in
+    /// this build (present in `dependentModules`) or a Swift framework that maps to a Skip module via
+    /// `moduleNameMap`. Used to filter `@_exported import` targets so that re-exports of native-only
+    /// Swift modules (e.g. `SwiftJNI`) do not become spurious Kotlin imports.
+    private func isSkipModuleName(_ moduleName: String) -> Bool {
+        if Self.moduleNameMap[moduleName] != nil {
+            return true
+        }
+        return dependentModules.contains(where: { $0.moduleName == moduleName })
     }
 
     /// Expand the given module names to include modules they transitively re-export via `@_exported import`.

--- a/Sources/SkipSyntax/CodebaseInfo.swift
+++ b/Sources/SkipSyntax/CodebaseInfo.swift
@@ -166,9 +166,9 @@ public final class CodebaseInfo {
         var queue = Array(moduleNames)
         // Build a name -> exports map, including the current module so source files that import it pick up its re-exports
         var exportsByModule: [String: [String]] = [:]
-        for dependentModule in dependentModules where !dependentModule.exportedModuleNames.isEmpty {
-            if let name = dependentModule.moduleName {
-                exportsByModule[name] = dependentModule.exportedModuleNames
+        for dependentModule in dependentModules {
+            if let name = dependentModule.moduleName, let exports = dependentModule.exportedModuleNames, !exports.isEmpty {
+                exportsByModule[name] = exports
             }
         }
         if let name = moduleName, !exportedModuleNames.isEmpty {
@@ -1454,9 +1454,11 @@ public final class CodebaseInfo {
 
         /// Names of modules this module re-exports via `@_exported import`.
         ///
-        /// Decoded as an optional field for backwards compatibility with `skipcode.json`
-        /// produced by older versions of skipstone that did not record this information.
-        public let exportedModuleNames: [String]
+        /// Declared optional so the auto-synthesized `Codable` conformance treats the field as a
+        /// backwards-compatible addition: `skipcode.json` files produced by older versions of
+        /// skipstone simply omit the key, and modules with no `@_exported import`s store `nil`
+        /// here so they also omit the key on encode.
+        public let exportedModuleNames: [String]?
 
         // Default visibility for testing
         var rootTypes: [TypeInfo] = []
@@ -1484,7 +1486,10 @@ public final class CodebaseInfo {
         public init(of codebaseInfo: CodebaseInfo) {
             self.moduleName = codebaseInfo.moduleName
             self.packageName = codebaseInfo.kotlin?.packageName
-            self.exportedModuleNames = codebaseInfo.exportedModuleNames
+            // Store `nil` (not an empty array) when the module has no `@_exported import`s so the
+            // synthesized encoder omits the key entirely, matching `skipcode.json` files produced
+            // by older skipstone versions byte-for-byte.
+            self.exportedModuleNames = codebaseInfo.exportedModuleNames.isEmpty ? nil : codebaseInfo.exportedModuleNames
 
             // We want to always produce the same encoded output for the same input, because new output from one module might be a signal
             // that modules depending on it have to re-transpile. Sort for stability. API within a file will always have been added in the
@@ -1498,36 +1503,6 @@ public final class CodebaseInfo {
             self.rootVariables = codebaseInfo.rootVariables.sorted(by: sortBy).filter(filter).map { replaceSourceFile(for: $0) }
             self.rootFunctions = codebaseInfo.rootFunctions.sorted(by: sortBy).filter(filter).map { replaceSourceFile(for: $0) }
             self.rootExtensions = codebaseInfo.rootExtensions.sorted(by: sortBy).compactMap { export(typeInfo: $0, filter: filter) }
-        }
-
-        public required init(from decoder: Decoder) throws {
-            let container = try decoder.container(keyedBy: CodingKeys.self)
-            self.moduleName = try container.decodeIfPresent(String.self, forKey: .moduleName)
-            self.packageName = try container.decodeIfPresent(String.self, forKey: .packageName)
-            // Backwards-compatible: older skipcode.json files predate `exportedModuleNames` and omit the key
-            self.exportedModuleNames = try container.decodeIfPresent([String].self, forKey: .exportedModuleNames) ?? []
-            self.rootTypes = try container.decodeIfPresent([TypeInfo].self, forKey: .rootTypes) ?? []
-            self.rootTypealiases = try container.decodeIfPresent([TypealiasInfo].self, forKey: .rootTypealiases) ?? []
-            self.rootVariables = try container.decodeIfPresent([VariableInfo].self, forKey: .rootVariables) ?? []
-            self.rootFunctions = try container.decodeIfPresent([FunctionInfo].self, forKey: .rootFunctions) ?? []
-            self.rootExtensions = try container.decodeIfPresent([TypeInfo].self, forKey: .rootExtensions) ?? []
-            self.sourceFileTable = try container.decodeIfPresent([String].self, forKey: .sourceFileTable) ?? []
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.container(keyedBy: CodingKeys.self)
-            try container.encodeIfPresent(moduleName, forKey: .moduleName)
-            try container.encodeIfPresent(packageName, forKey: .packageName)
-            try container.encode(rootTypes, forKey: .rootTypes)
-            try container.encode(rootTypealiases, forKey: .rootTypealiases)
-            try container.encode(rootVariables, forKey: .rootVariables)
-            try container.encode(rootFunctions, forKey: .rootFunctions)
-            try container.encode(rootExtensions, forKey: .rootExtensions)
-            try container.encode(sourceFileTable, forKey: .sourceFileTable)
-            // Omit the key entirely when empty to keep encoded output identical to older skipstone for modules without `@_exported` imports
-            if !exportedModuleNames.isEmpty {
-                try container.encode(exportedModuleNames, forKey: .exportedModuleNames)
-            }
         }
 
         private func export(typeInfo: TypeInfo, filter: (CodebaseInfoItem) -> Bool) -> TypeInfo? {

--- a/Sources/SkipSyntax/HelperTypes.swift
+++ b/Sources/SkipSyntax/HelperTypes.swift
@@ -1202,6 +1202,16 @@ extension Array where Element == Statement {
         }
     }
 
+    /// Parse import statements for imports marked `@_exported`.
+    var exportedImportedModulePaths: [[String]] {
+        return compactMap { statement in
+            guard statement.type == .importDeclaration, let importDeclaration = statement as? ImportDeclaration, importDeclaration.isExported else {
+                return nil
+            }
+            return importDeclaration.modulePath
+        }
+    }
+
     /// Whether these statements include a declaration of the given type (no extensions).
     func containsDeclaration(of signature: TypeSignature) -> Bool {
         let name = signature.name

--- a/Sources/SkipSyntax/Kotlin/KotlinImportsTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinImportsTransformer.swift
@@ -84,9 +84,9 @@ final class KotlinImportsTransformer: KotlinTransformer {
     /// Build a lookup from the importable module name (the post-mapping module name, e.g., `SkipSQL`) to the list of modules it re-exports.
     private func exportedModuleNamesByModuleName(in codebaseInfo: CodebaseInfo) -> [String: [String]] {
         var result: [String: [String]] = [:]
-        for dependentModule in codebaseInfo.dependentModules where !dependentModule.exportedModuleNames.isEmpty {
-            if let moduleName = dependentModule.moduleName {
-                result[moduleName] = dependentModule.exportedModuleNames
+        for dependentModule in codebaseInfo.dependentModules {
+            if let moduleName = dependentModule.moduleName, let exports = dependentModule.exportedModuleNames, !exports.isEmpty {
+                result[moduleName] = exports
             }
         }
         // The current module's own `@_exported import`s should also propagate when source files re-import the current module under a different name in tests.

--- a/Sources/SkipSyntax/Kotlin/KotlinImportsTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinImportsTransformer.swift
@@ -6,9 +6,11 @@
 final class KotlinImportsTransformer: KotlinTransformer {
     func apply(to syntaxTree: KotlinSyntaxTree, translator: KotlinTranslator) -> [KotlinTransformerOutput] {
         // There's no point in running this transformer in the symbol gathering phase
-        guard translator.codebaseInfo != nil else {
+        guard let codebaseInfoContext = translator.codebaseInfo else {
             return []
         }
+
+        let exportedModuleNamesByModuleName = exportedModuleNamesByModuleName(in: codebaseInfoContext.global)
 
         // Translate imports and remove redundancies
         var importPaths: Set<[String]> = []
@@ -48,6 +50,26 @@ final class KotlinImportsTransformer: KotlinTransformer {
                 }
             }
         }
+
+        // For every imported module that re-exports other modules via `@_exported import`, also emit those imports.
+        // We walk transitively so that re-exports of re-exports are followed.
+        let allModulePaths = importPaths
+        var queue: [[String]] = Array(allModulePaths)
+        while let modulePath = queue.popLast() {
+            guard modulePath.count == 1, let exportedModuleNames = exportedModuleNamesByModuleName[modulePath[0]] else {
+                continue
+            }
+            for exportedModuleName in exportedModuleNames {
+                let exportedModulePaths = translateImport(modulePath: [exportedModuleName])
+                for exportedModulePath in exportedModulePaths {
+                    if importPaths.insert(exportedModulePath).inserted {
+                        additionalImportDeclarations.append(KotlinImportDeclaration(modulePath: exportedModulePath, unmappedModulePath: [exportedModuleName]))
+                        queue.append(exportedModulePath)
+                    }
+                }
+            }
+        }
+
         syntaxTree.root.insert(statements: additionalImportDeclarations, after: lastImportDeclaration)
         return []
     }
@@ -57,5 +79,20 @@ final class KotlinImportsTransformer: KotlinTransformer {
             return skipModuleNames.map { [$0] }
         }
         return [modulePath]
+    }
+
+    /// Build a lookup from the importable module name (the post-mapping module name, e.g., `SkipSQL`) to the list of modules it re-exports.
+    private func exportedModuleNamesByModuleName(in codebaseInfo: CodebaseInfo) -> [String: [String]] {
+        var result: [String: [String]] = [:]
+        for dependentModule in codebaseInfo.dependentModules where !dependentModule.exportedModuleNames.isEmpty {
+            if let moduleName = dependentModule.moduleName {
+                result[moduleName] = dependentModule.exportedModuleNames
+            }
+        }
+        // The current module's own `@_exported import`s should also propagate when source files re-import the current module under a different name in tests.
+        if let moduleName = codebaseInfo.moduleName, !codebaseInfo.exportedModuleNames.isEmpty {
+            result[moduleName] = codebaseInfo.exportedModuleNames
+        }
+        return result
     }
 }

--- a/Sources/SkipSyntax/StatementTypes.swift
+++ b/Sources/SkipSyntax/StatementTypes.swift
@@ -1244,9 +1244,12 @@ final class FunctionDeclaration: Statement {
 /// `import Module`
 final class ImportDeclaration: Statement {
     let modulePath: [String]
+    /// Whether the import is marked `@_exported`, meaning Swift will re-export the imported module's API as part of the importing module.
+    let isExported: Bool
 
-    init(modulePath: [String], syntax: SyntaxProtocol? = nil, sourceFile: Source.FilePath? = nil, sourceRange: Source.Range? = nil, extras: StatementExtras? = nil) {
+    init(modulePath: [String], isExported: Bool = false, syntax: SyntaxProtocol? = nil, sourceFile: Source.FilePath? = nil, sourceRange: Source.Range? = nil, extras: StatementExtras? = nil) {
         self.modulePath = modulePath
+        self.isExported = isExported
         super.init(type: .importDeclaration, syntax: syntax, sourceFile: sourceFile, sourceRange: sourceRange, extras: extras)
     }
 
@@ -1255,12 +1258,20 @@ final class ImportDeclaration: Statement {
             return nil
         }
         let modulePath = importDecl.path.map { $0.name.text }
-        let statement = ImportDeclaration(modulePath: modulePath, syntax: syntax, sourceFile: syntaxTree.source.file, sourceRange: syntax.range(in: syntaxTree.source), extras: extras)
+        let isExported = importDecl.attributes.contains(where: { element in
+            guard let attribute = element.as(AttributeSyntax.self) else { return false }
+            return attribute.attributeName.description.trimmingCharacters(in: .whitespaces) == "_exported"
+        })
+        let statement = ImportDeclaration(modulePath: modulePath, isExported: isExported, syntax: syntax, sourceFile: syntaxTree.source.file, sourceRange: syntax.range(in: syntaxTree.source), extras: extras)
         return [statement]
     }
 
     override var prettyPrintAttributes: [PrettyPrintTree] {
-        return [PrettyPrintTree(root: modulePath.joined(separator: "."))]
+        var label = modulePath.joined(separator: ".")
+        if isExported {
+            label = "@_exported " + label
+        }
+        return [PrettyPrintTree(root: label)]
     }
 }
 

--- a/Tests/SkipSyntaxTests/ExportedImportTests.swift
+++ b/Tests/SkipSyntaxTests/ExportedImportTests.swift
@@ -97,32 +97,36 @@ final class ExportedImportTests: XCTestCase {
         @_exported import Inner
         """)
         let original = CodebaseInfo.ModuleExport(of: info)
-        XCTAssertEqual(["Inner"], original.exportedModuleNames)
+        XCTAssertEqual(["Inner"], original.exportedModuleNames ?? [])
 
         let data = try JSONEncoder().encode(original)
         let decoded = try JSONDecoder().decode(CodebaseInfo.ModuleExport.self, from: data)
-        XCTAssertEqual(["Inner"], decoded.exportedModuleNames)
+        XCTAssertEqual(["Inner"], decoded.exportedModuleNames ?? [])
     }
 
-    /// A `ModuleExport` without `exportedModuleNames` (older skipcode.json) decodes with an empty list,
-    /// preserving backwards compatibility.
+    /// A `ModuleExport` whose source JSON predates the `x` (exportedModuleNames) key — i.e. one
+    /// produced by an older skipstone version — decodes cleanly, with `exportedModuleNames` set
+    /// to `nil` via the synthesized optional decoder. Other long-standing keys are present.
     func testModuleExportBackwardsCompatibleDecoding() throws {
-        let legacyJSON = #"{"m":"Legacy","p":"legacy"}"#
+        // Mirror the shape of a real older skipcode.json: all of the original keys present, the new
+        // `x` key absent. This is the only difference between old and new encodings that we need to
+        // tolerate, since older skipstone always emitted the original keys.
+        let legacyJSON = #"{"m":"Legacy","p":"legacy","t":[],"a":[],"v":[],"f":[],"e":[],"stable":[]}"#
         let data = Data(legacyJSON.utf8)
         let decoded = try JSONDecoder().decode(CodebaseInfo.ModuleExport.self, from: data)
         XCTAssertEqual("Legacy", decoded.moduleName)
         XCTAssertEqual("legacy", decoded.packageName)
-        XCTAssertEqual([], decoded.exportedModuleNames)
+        XCTAssertNil(decoded.exportedModuleNames)
     }
 
-    /// A `ModuleExport` with no `@_exported import`s should omit the `x` key entirely,
-    /// matching skipcode.json files produced by older skipstone versions.
+    /// A `ModuleExport` with no `@_exported import`s stores `nil` and the synthesized encoder
+    /// omits the `x` key, matching skipcode.json files produced by older skipstone versions.
     func testModuleExportEncodingOmitsEmptyExportedModuleNames() throws {
         let info = try codebaseInfo(moduleName: "Plain", swift: """
         public class A {}
         """)
         let export = CodebaseInfo.ModuleExport(of: info)
-        XCTAssertEqual([], export.exportedModuleNames)
+        XCTAssertNil(export.exportedModuleNames)
 
         let data = try JSONEncoder().encode(export)
         let json = String(data: data, encoding: .utf8) ?? ""

--- a/Tests/SkipSyntaxTests/ExportedImportTests.swift
+++ b/Tests/SkipSyntaxTests/ExportedImportTests.swift
@@ -16,7 +16,8 @@ final class ExportedImportTests: XCTestCase {
     /// `CodebaseInfo` records the names of modules re-exported via `@_exported import` so that
     /// dependent modules can pick them up at translation time.
     func testCodebaseInfoRecordsExportedModuleNames() throws {
-        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        let inner = try moduleExport(named: "Inner")
+        let info = try codebaseInfo(moduleName: "Umbrella", dependentModules: [inner], swift: """
         @_exported import Inner
         import Other
 
@@ -28,7 +29,9 @@ final class ExportedImportTests: XCTestCase {
 
     /// Multiple `@_exported import` declarations stack up, while plain imports do not.
     func testCodebaseInfoRecordsMultipleExportedModuleNames() throws {
-        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        let innerA = try moduleExport(named: "InnerA")
+        let innerB = try moduleExport(named: "InnerB")
+        let info = try codebaseInfo(moduleName: "Umbrella", dependentModules: [innerA, innerB], swift: """
         @_exported import InnerA
         @_exported import InnerB
         import Other
@@ -41,7 +44,9 @@ final class ExportedImportTests: XCTestCase {
 
     /// A duplicated `@_exported import` of the same module is only recorded once.
     func testCodebaseInfoDeduplicatesExportedModuleNames() throws {
+        let inner = try moduleExport(named: "Inner")
         let info = CodebaseInfo(moduleName: "Umbrella")
+        info.dependentModules = [inner]
         info.gather(from: try syntaxTree(forSwift: """
         @_exported import Inner
 
@@ -57,9 +62,38 @@ final class ExportedImportTests: XCTestCase {
         XCTAssertEqual(["Inner"], info.exportedModuleNames)
     }
 
+    /// `@_exported import` of a module that Skip does not transpile (no `ModuleExport`, not in
+    /// the built-in name map) must NOT be recorded — otherwise the transpiler would later emit
+    /// a Kotlin import for a package that does not exist on the JVM. This case matches
+    /// `@_exported import SwiftJNI` in `SkipBridge`, where `SwiftJNI` is a native-only Swift
+    /// module without a Kotlin counterpart.
+    func testCodebaseInfoIgnoresNonSkipExportedModuleNames() throws {
+        let info = try codebaseInfo(moduleName: "SkipBridge", dependentModules: [], swift: """
+        @_exported import SwiftJNI
+
+        public class Wrapped {}
+        """)
+
+        XCTAssertEqual([], info.exportedModuleNames)
+    }
+
+    /// `@_exported import` targets that are Swift frameworks with a built-in mapping to a Skip
+    /// module (e.g. `Foundation` → `SkipFoundation`) are recorded so that the transpiler can
+    /// propagate them through the existing import translation.
+    func testCodebaseInfoRecordsMappedFrameworkExportedModuleNames() throws {
+        let info = try codebaseInfo(moduleName: "Umbrella", dependentModules: [], swift: """
+        @_exported import Foundation
+
+        public class Wrapped {}
+        """)
+
+        XCTAssertEqual(["Foundation"], info.exportedModuleNames)
+    }
+
     /// A `ModuleExport` round-trip through JSON preserves `exportedModuleNames`.
     func testModuleExportRoundTrip() throws {
-        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        let inner = try moduleExport(named: "Inner")
+        let info = try codebaseInfo(moduleName: "Umbrella", dependentModules: [inner], swift: """
         @_exported import Inner
         """)
         let original = CodebaseInfo.ModuleExport(of: info)
@@ -104,7 +138,7 @@ final class ExportedImportTests: XCTestCase {
             public func value() -> Int { return 0 }
         }
         """))
-        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", swift: """
+        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", dependentModules: [inner], swift: """
         @_exported import Inner
 
         public class UmbrellaType {
@@ -135,12 +169,12 @@ final class ExportedImportTests: XCTestCase {
             public func value() -> Int { return 0 }
         }
         """))
-        let middle = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Middle", swift: """
+        let middle = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Middle", dependentModules: [inner], swift: """
         @_exported import Inner
 
         public class MiddleType { public init() {} }
         """))
-        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", swift: """
+        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", dependentModules: [middle, inner], swift: """
         @_exported import Middle
 
         public class UmbrellaType { public init() {} }
@@ -187,11 +221,18 @@ final class ExportedImportTests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func codebaseInfo(moduleName: String, swift: String) throws -> CodebaseInfo {
+    private func codebaseInfo(moduleName: String, dependentModules: [CodebaseInfo.ModuleExport] = [], swift: String) throws -> CodebaseInfo {
         let codebaseInfo = CodebaseInfo(moduleName: moduleName)
+        codebaseInfo.dependentModules = dependentModules
         codebaseInfo.gather(from: try syntaxTree(forSwift: swift, named: moduleName))
         codebaseInfo.prepareForUse()
         return codebaseInfo
+    }
+
+    /// Build a minimal `ModuleExport` for a Skip module with no API, sufficient to register the name
+    /// in `CodebaseInfo.dependentModules` for `@_exported` filtering.
+    private func moduleExport(named name: String) throws -> CodebaseInfo.ModuleExport {
+        return CodebaseInfo.ModuleExport(of: try codebaseInfo(moduleName: name, swift: ""))
     }
 
     private func syntaxTree(forSwift swift: String, named name: String) throws -> SyntaxTree {

--- a/Tests/SkipSyntaxTests/ExportedImportTests.swift
+++ b/Tests/SkipSyntaxTests/ExportedImportTests.swift
@@ -1,0 +1,202 @@
+// Copyright (c) 2023 - 2026 Skip
+// Licensed under the GNU Affero General Public License v3.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+@testable import SkipSyntax
+import XCTest
+
+/// Tests for `@_exported import` umbrella re-export support.
+///
+/// When a Swift module marks an import as `@_exported`, types from the imported module are
+/// visible to code that imports the umbrella module without naming the underlying one. The
+/// transpiler needs to emit the matching Kotlin imports so that the same is true for the
+/// transpiled output.
+final class ExportedImportTests: XCTestCase {
+    /// `CodebaseInfo` records the names of modules re-exported via `@_exported import` so that
+    /// dependent modules can pick them up at translation time.
+    func testCodebaseInfoRecordsExportedModuleNames() throws {
+        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        @_exported import Inner
+        import Other
+
+        public class Wrapped {}
+        """)
+
+        XCTAssertEqual(["Inner"], info.exportedModuleNames)
+    }
+
+    /// Multiple `@_exported import` declarations stack up, while plain imports do not.
+    func testCodebaseInfoRecordsMultipleExportedModuleNames() throws {
+        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        @_exported import InnerA
+        @_exported import InnerB
+        import Other
+
+        public class Wrapped {}
+        """)
+
+        XCTAssertEqual(["InnerA", "InnerB"], info.exportedModuleNames)
+    }
+
+    /// A duplicated `@_exported import` of the same module is only recorded once.
+    func testCodebaseInfoDeduplicatesExportedModuleNames() throws {
+        let info = CodebaseInfo(moduleName: "Umbrella")
+        info.gather(from: try syntaxTree(forSwift: """
+        @_exported import Inner
+
+        public class FirstFile {}
+        """, named: "First"))
+        info.gather(from: try syntaxTree(forSwift: """
+        @_exported import Inner
+
+        public class SecondFile {}
+        """, named: "Second"))
+        info.prepareForUse()
+
+        XCTAssertEqual(["Inner"], info.exportedModuleNames)
+    }
+
+    /// A `ModuleExport` round-trip through JSON preserves `exportedModuleNames`.
+    func testModuleExportRoundTrip() throws {
+        let info = try codebaseInfo(moduleName: "Umbrella", swift: """
+        @_exported import Inner
+        """)
+        let original = CodebaseInfo.ModuleExport(of: info)
+        XCTAssertEqual(["Inner"], original.exportedModuleNames)
+
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CodebaseInfo.ModuleExport.self, from: data)
+        XCTAssertEqual(["Inner"], decoded.exportedModuleNames)
+    }
+
+    /// A `ModuleExport` without `exportedModuleNames` (older skipcode.json) decodes with an empty list,
+    /// preserving backwards compatibility.
+    func testModuleExportBackwardsCompatibleDecoding() throws {
+        let legacyJSON = #"{"m":"Legacy","p":"legacy"}"#
+        let data = Data(legacyJSON.utf8)
+        let decoded = try JSONDecoder().decode(CodebaseInfo.ModuleExport.self, from: data)
+        XCTAssertEqual("Legacy", decoded.moduleName)
+        XCTAssertEqual("legacy", decoded.packageName)
+        XCTAssertEqual([], decoded.exportedModuleNames)
+    }
+
+    /// A `ModuleExport` with no `@_exported import`s should omit the `x` key entirely,
+    /// matching skipcode.json files produced by older skipstone versions.
+    func testModuleExportEncodingOmitsEmptyExportedModuleNames() throws {
+        let info = try codebaseInfo(moduleName: "Plain", swift: """
+        public class A {}
+        """)
+        let export = CodebaseInfo.ModuleExport(of: info)
+        XCTAssertEqual([], export.exportedModuleNames)
+
+        let data = try JSONEncoder().encode(export)
+        let json = String(data: data, encoding: .utf8) ?? ""
+        XCTAssertFalse(json.contains("\"x\""), "Expected the 'x' (exportedModuleNames) key to be omitted when empty; got: \(json)")
+    }
+
+    /// Importing an umbrella module that re-exports another module in Swift should produce
+    /// Kotlin imports for both the umbrella package and the re-exported package.
+    func testTranspiledImportPullsInExportedModule() async throws {
+        let inner = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Inner", swift: """
+        public class InnerType {
+            public init() {}
+            public func value() -> Int { return 0 }
+        }
+        """))
+        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", swift: """
+        @_exported import Inner
+
+        public class UmbrellaType {
+            public init() {}
+        }
+        """))
+
+        try await check(dependentModules: [inner, umbrella], swift: """
+        import Umbrella
+
+        func f() -> Int {
+            return InnerType().value()
+        }
+        """, kotlin: """
+        import umbrella.module.*
+        import inner.module.*
+
+        internal fun f(): Int = InnerType().value()
+        """)
+    }
+
+    /// `@_exported` propagation walks through chains: if A re-exports B and B re-exports C,
+    /// then `import A` should pull in B and C.
+    func testTranspiledImportPullsInTransitivelyExportedModules() async throws {
+        let inner = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Inner", swift: """
+        public class InnerType {
+            public init() {}
+            public func value() -> Int { return 0 }
+        }
+        """))
+        let middle = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Middle", swift: """
+        @_exported import Inner
+
+        public class MiddleType { public init() {} }
+        """))
+        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", swift: """
+        @_exported import Middle
+
+        public class UmbrellaType { public init() {} }
+        """))
+
+        try await check(dependentModules: [inner, middle, umbrella], swift: """
+        import Umbrella
+
+        func f() -> Int {
+            return InnerType().value()
+        }
+        """, kotlin: """
+        import umbrella.module.*
+        import middle.module.*
+        import inner.module.*
+
+        internal fun f(): Int = InnerType().value()
+        """)
+    }
+
+    /// A plain (non-`@_exported`) `import` should not be propagated when the importer is used elsewhere.
+    func testPlainImportIsNotPropagated() async throws {
+        let inner = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Inner", swift: """
+        public class InnerType { public init() {} }
+        """))
+        let umbrella = try CodebaseInfo.ModuleExport(of: codebaseInfo(moduleName: "Umbrella", swift: """
+        import Inner
+
+        public class UmbrellaType { public init() {} }
+        """))
+
+        try await check(dependentModules: [inner, umbrella], swift: """
+        import Umbrella
+
+        func f() -> UmbrellaType {
+            return UmbrellaType()
+        }
+        """, kotlin: """
+        import umbrella.module.*
+
+        internal fun f(): UmbrellaType = UmbrellaType()
+        """)
+    }
+
+    // MARK: - Helpers
+
+    private func codebaseInfo(moduleName: String, swift: String) throws -> CodebaseInfo {
+        let codebaseInfo = CodebaseInfo(moduleName: moduleName)
+        codebaseInfo.gather(from: try syntaxTree(forSwift: swift, named: moduleName))
+        codebaseInfo.prepareForUse()
+        return codebaseInfo
+    }
+
+    private func syntaxTree(forSwift swift: String, named name: String) throws -> SyntaxTree {
+        let srcFile = try tmpFile(named: "Source_\(name).swift", contents: swift)
+        let source = Source(file: Source.FilePath(path: srcFile.path), content: swift)
+        return SyntaxTree(source: source)
+    }
+}


### PR DESCRIPTION
Enables transpiled Skip modules to respect `@_exported import SomeModuleName` on the Kotlin side.