### PR TITLE
Mark bridged async return values `nonisolated(unsafe)` for Swift 6 region isolation

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeToSwiftVisitor.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeToSwiftVisitor.swift
@@ -644,7 +644,13 @@ final class KotlinBridgeToSwiftVisitor {
                 swift.append(indentation.inc(), "f_continuation.resume()")
             } else if !isThrows {
                 swift.append(indentation, "let f_return_callback: @Sendable \(callbackType) = { f_return in")
-                swift.append(indentation.inc(), "f_continuation.resume(returning: f_return)")
+                // The bridged return value may be non-Sendable (e.g. a `BridgedFromKotlin`
+                // projection wrapping a JNI handle). It is delivered exactly once by the JNI
+                // completion callback and handed straight to the continuation, so transferring
+                // it across the `sending` boundary of `resume(returning:)` is safe even under
+                // Swift 6 region-based isolation. `nonisolated(unsafe)` asserts that.
+                swift.append(indentation.inc(), "nonisolated(unsafe) let f_return_value = f_return")
+                swift.append(indentation.inc(), "f_continuation.resume(returning: f_return_value)")
             } else {
                 if callbackType.parameters.count == 1 {
                     swift.append(indentation, "let f_return_callback: @Sendable \(callbackType) = { f_error in")
@@ -658,9 +664,16 @@ final class KotlinBridgeToSwiftVisitor {
                 if callbackType.parameters.count == 1 {
                     swift.append(indentation.inc(), "f_continuation.resume()")
                 } else if bridgable.return.type.isOptional {
-                    swift.append(indentation.inc(), "f_continuation.resume(returning: f_return)")
+                    // The bridged return value may be non-Sendable (e.g. a `BridgedFromKotlin`
+                // projection wrapping a JNI handle). It is delivered exactly once by the JNI
+                // completion callback and handed straight to the continuation, so transferring
+                // it across the `sending` boundary of `resume(returning:)` is safe even under
+                // Swift 6 region-based isolation. `nonisolated(unsafe)` asserts that.
+                swift.append(indentation.inc(), "nonisolated(unsafe) let f_return_value = f_return")
+                swift.append(indentation.inc(), "f_continuation.resume(returning: f_return_value)")
                 } else {
-                    swift.append(indentation.inc(), "f_continuation.resume(returning: f_return!)")
+                    swift.append(indentation.inc(), "nonisolated(unsafe) let f_return_value = f_return!")
+                    swift.append(indentation.inc(), "f_continuation.resume(returning: f_return_value)")
                 }
                 swift.append(indentation, "}")
                 indentation = indentation.dec()

--- a/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToKotlinTests.swift
@@ -4646,7 +4646,8 @@ final class BridgeToKotlinTests: XCTestCase {
                         if let f_error {
                             f_continuation.resume(throwing: JThrowable.toError(f_error, options: [.kotlincompat])!)
                         } else {
-                            f_continuation.resume(returning: f_return!)
+                            nonisolated(unsafe) let f_return_value = f_return!
+                            f_continuation.resume(returning: f_return_value)
                         }
                     }
                     jniContext {
@@ -5811,7 +5812,8 @@ final class BridgeToKotlinTests: XCTestCase {
                         if let f_error {
                             f_continuation.resume(throwing: JThrowable.toError(f_error, options: [.kotlincompat])!)
                         } else {
-                            f_continuation.resume(returning: f_return!)
+                            nonisolated(unsafe) let f_return_value = f_return!
+                            f_continuation.resume(returning: f_return_value)
                         }
                     }
                     jniContext {

--- a/Tests/SkipSyntaxTests/BridgeToSwiftTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeToSwiftTests.swift
@@ -565,7 +565,8 @@ final class BridgeToSwiftTests: XCTestCase {
             get async {
                 return await withCheckedContinuation { f_continuation in
                     let f_return_callback: @Sendable (Int) -> Void = { f_return in
-                        f_continuation.resume(returning: f_return)
+                        nonisolated(unsafe) let f_return_value = f_return
+                        f_continuation.resume(returning: f_return_value)
                     }
                     jniContext {
                         let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -609,7 +610,8 @@ final class BridgeToSwiftTests: XCTestCase {
                         if let f_error {
                             f_continuation.resume(throwing: JThrowable.toError(f_error, options: [])!)
                         } else {
-                            f_continuation.resume(returning: f_return!)
+                            nonisolated(unsafe) let f_return_value = f_return!
+                            f_continuation.resume(returning: f_return_value)
                         }
                     }
                     jniContext {
@@ -1407,7 +1409,8 @@ final class BridgeToSwiftTests: XCTestCase {
         public func f(i p_0: Int) async -> Int {
             return await withCheckedContinuation { f_continuation in
                 let f_return_callback: @Sendable (Int) -> Void = { f_return in
-                    f_continuation.resume(returning: f_return)
+                    nonisolated(unsafe) let f_return_value = f_return
+                    f_continuation.resume(returning: f_return_value)
                 }
                 jniContext {
                     let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -1442,7 +1445,8 @@ final class BridgeToSwiftTests: XCTestCase {
         public func f(i p_0: Int) async -> Int {
             return await withCheckedContinuation { f_continuation in
                 let f_return_callback: @Sendable (Int) -> Void = { f_return in
-                    f_continuation.resume(returning: f_return)
+                    nonisolated(unsafe) let f_return_value = f_return
+                    f_continuation.resume(returning: f_return_value)
                 }
                 jniContext {
                     let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -1514,7 +1518,8 @@ final class BridgeToSwiftTests: XCTestCase {
                     if let f_error {
                         f_continuation.resume(throwing: JThrowable.toError(f_error, options: [])!)
                     } else {
-                        f_continuation.resume(returning: f_return!)
+                        nonisolated(unsafe) let f_return_value = f_return!
+                        f_continuation.resume(returning: f_return_value)
                     }
                 }
                 jniContext {
@@ -2292,7 +2297,8 @@ final class BridgeToSwiftTests: XCTestCase {
             public func add() async -> Int {
                 return await withCheckedContinuation { f_continuation in
                     let f_return_callback: @Sendable (Int) -> Void = { f_return in
-                        f_continuation.resume(returning: f_return)
+                        nonisolated(unsafe) let f_return_value = f_return
+                        f_continuation.resume(returning: f_return_value)
                     }
                     jniContext {
                         let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -4497,7 +4503,8 @@ final class BridgeToSwiftTests: XCTestCase {
                 get async {
                     return await withCheckedContinuation { f_continuation in
                         let f_return_callback: @Sendable (Int) -> Void = { f_return in
-                            f_continuation.resume(returning: f_return)
+                            nonisolated(unsafe) let f_return_value = f_return
+                            f_continuation.resume(returning: f_return_value)
                         }
                         jniContext {
                             let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -4528,7 +4535,8 @@ final class BridgeToSwiftTests: XCTestCase {
             public func f(i p_0: Int) async -> String {
                 return await withCheckedContinuation { f_continuation in
                     let f_return_callback: @Sendable (String) -> Void = { f_return in
-                        f_continuation.resume(returning: f_return)
+                        nonisolated(unsafe) let f_return_value = f_return
+                        f_continuation.resume(returning: f_return_value)
                     }
                     jniContext {
                         let f_return_callback_java = SwiftClosure1.javaObject(for: f_return_callback, options: []).toJavaParameter(options: [])
@@ -5397,7 +5405,8 @@ final class BridgeToSwiftTests: XCTestCase {
                     if let f_error {
                         f_continuation.resume(throwing: JThrowable.toError(f_error, options: [])!)
                     } else {
-                        f_continuation.resume(returning: f_return!)
+                        nonisolated(unsafe) let f_return_value = f_return!
+                        f_continuation.resume(returning: f_return_value)
                     }
                 }
                 jniContext {


### PR DESCRIPTION
This should resolve the Android compile errors in https://github.com/skiptools/skip-firebase/pull/87