### PR TITLE
Don't JNI-bridge generic @inline(__always) functions

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -1109,6 +1109,15 @@ extension KotlinFunctionDeclaration {
             messages.append(.kotlinBridgeUnsupportedFeature(self, feature: "optional inits", source: translator.syntaxTree.source))
             return nil
         }
+        // A generic `@inline(__always)` function is emitted as a Kotlin `inline fun <reified T>` (see
+        // KotlinStatementTypes isInline / the extension-function form used for reified generics of a
+        // virtual type). An inline reified function has no JVM-callable method, so a JNI getMethodID
+        // lookup for it returns nil and the generated bridge's force-unwrap traps at class load for
+        // native-Swift Android callers (skiptools/skip-firebase#81, #91). Do not JNI-bridge it —
+        // native-Swift callers use the @inline(__always) Swift body directly (inlined).
+        guard !(attributes.contains(.inlineAlways) && !generics.isEmpty) else {
+            return nil
+        }
         if direction == .toKotlin {
             guard isEqualImplementation || isLessThanImplementation || checkNonStaticGenericTypeMember(self, in: parent, modifiers: modifiers, translator: translator) else {
                 return nil

--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -1118,6 +1118,14 @@ extension KotlinFunctionDeclaration {
         guard !(attributes.contains(.inlineAlways) && !generics.isEmpty) else {
             return nil
         }
+        // The same JVM-uncallable `inline fun <reified T>` can also be hand-authored via a
+        // `// SKIP DECLARE: ... inline fun <reified T> ...` override, which carries no structured
+        // attribute for the guard above to see (e.g. skip-firebase's FirestoreDecoder.decode(from:),
+        // reached through DocumentSnapshot.decoded() — so #91 is not fully closed by the attribute
+        // guard alone). Bail out for that override shape too.
+        if let declaration = extras?.declaration, declaration.contains("inline fun"), declaration.contains("reified") {
+            return nil
+        }
         if direction == .toKotlin {
             guard isEqualImplementation || isLessThanImplementation || checkNonStaticGenericTypeMember(self, in: parent, modifiers: modifiers, translator: translator) else {
                 return nil

--- a/Tests/SkipSyntaxTests/BridgeInlineReifiedTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeInlineReifiedTests.swift
@@ -1,0 +1,107 @@
+// Copyright (c) 2023 - 2026 Skip
+// Licensed under the GNU Affero General Public License v3.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import SkipSyntax
+import XCTest
+
+// Regression for skiptools/skip-firebase#81 / #91: a generic `@inline(__always)` function is
+// emitted as a Kotlin `inline fun <reified T>`, which has NO JVM-callable method. The bridge
+// generator must therefore NOT emit a JNI getMethodID lookup for it — that force-unwrap
+// (`getMethodID("decoded", ...)!`) returns nil and traps at class load for native-Swift Android
+// callers. Native-Swift callers use the `@inline(__always)` Swift body directly (inlined).
+// Reproduces on an `open` class that has a subclass (the #91 shape, where the reified method is
+// lifted to an extension function).
+final class BridgeInlineReifiedTests: XCTestCase {
+    private var transformers: [KotlinTransformer] {
+        return builtinKotlinTransformers() + [KotlinBridgeTransformer()]
+    }
+
+    func testReifiedInlineMethodIsNotBridged() async throws {
+        try await check(swift: """
+        #if !SKIP_BRIDGE
+        open class SnapC {
+            @inline(__always) public func decoded<T: Decodable>() throws -> T { fatalError() }
+        }
+        public final class QuerySnapC: SnapC {
+        }
+        #endif
+        """, kotlin: """
+        open class SnapC: skip.lib.SwiftProjecting {
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+
+            companion object: CompanionClass() {
+            }
+            open class CompanionClass {
+            }
+        }
+
+        inline fun <reified T> SnapC.decoded(): T where T: Decodable {
+            fatalError()
+        }
+        class QuerySnapC: SnapC() {
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+
+            companion object: SnapC.CompanionClass() {
+            }
+        }
+        """, swiftBridgeSupport: """
+        open class SnapC: BridgedFromKotlin {
+            nonisolated private static let Java_class = try! JClass(name: "SnapC")
+            nonisolated public let Java_peer: JObject
+            nonisolated public required init(Java_ptr: JavaObjectPointer) {
+                Java_peer = JObject(Java_ptr)
+            }
+            nonisolated public init(Java_peer: JObject) {
+                self.Java_peer = Java_peer
+            }
+            public init() {
+                Java_peer = jniContext {
+                    let ptr = try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: [], args: [])
+                    return JObject(ptr)
+                }
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "()V")!
+            nonisolated public static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                return .init(Java_ptr: obj!)
+            }
+            nonisolated public func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                return Java_peer.safePointer()
+            }
+        }
+        @_cdecl("Java_SnapC_Swift_1projectionImpl")
+        public func SnapC_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = SnapC.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        public final class QuerySnapC: SnapC, BridgedFinalClass {
+            nonisolated private static let Java_class = try! JClass(name: "QuerySnapC")
+            nonisolated public required init(Java_ptr: JavaObjectPointer) {
+                super.init(Java_ptr: Java_ptr)
+            }
+            nonisolated public override init(Java_peer: JObject) {
+                super.init(Java_peer: Java_peer)
+            }
+            public init() {
+                let Java_peer = jniContext {
+                    let ptr = try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: [], args: [])
+                    return JObject(ptr)
+                }
+                super.init(Java_peer: Java_peer)
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "()V")!
+        }
+        @_cdecl("Java_QuerySnapC_Swift_1projectionImpl")
+        public func QuerySnapC_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = QuerySnapC.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
+}

--- a/Tests/SkipSyntaxTests/BridgeInlineReifiedTests.swift
+++ b/Tests/SkipSyntaxTests/BridgeInlineReifiedTests.swift
@@ -104,4 +104,64 @@ final class BridgeInlineReifiedTests: XCTestCase {
         }
         """, transformers: transformers)
     }
+
+    // Same JVM-uncallable inline-reified shape, but hand-authored via `// SKIP DECLARE:` (no
+    // `@inline(__always)` attribute). This is skip-firebase's FirestoreDecoder.decode(from:) shape,
+    // reached from DocumentSnapshot.decoded() — so #91 is only fully closed once this path is
+    // excluded from bridging too. Assert no `getMethodID(name: "decode"` lookup is generated.
+    func testSkipDeclareReifiedMethodIsNotBridged() async throws {
+        try await check(swift: """
+        #if !SKIP_BRIDGE
+        public class Decoder {
+            // SKIP DECLARE: public inline fun <reified T : Decodable> decode(from: Dictionary<String, Any>): T
+            public func decode<T: Decodable>(from data: [String: Any]) throws -> T { fatalError() }
+        }
+        #endif
+        """, kotlin: """
+        open class Decoder: skip.lib.SwiftProjecting {
+            public inline fun <reified T : Decodable> decode(from: Dictionary<String, Any>): T {
+                val data = from
+                fatalError()
+            }
+
+            override fun Swift_projection(options: Int): () -> Any = Swift_projectionImpl(options)
+            private external fun Swift_projectionImpl(options: Int): () -> Any
+
+            companion object: CompanionClass() {
+            }
+            open class CompanionClass {
+            }
+        }
+        """, swiftBridgeSupport: """
+        public class Decoder: BridgedFromKotlin {
+            nonisolated private static let Java_class = try! JClass(name: "Decoder")
+            nonisolated public let Java_peer: JObject
+            nonisolated public required init(Java_ptr: JavaObjectPointer) {
+                Java_peer = JObject(Java_ptr)
+            }
+            nonisolated public init(Java_peer: JObject) {
+                self.Java_peer = Java_peer
+            }
+            public init() {
+                Java_peer = jniContext {
+                    let ptr = try! Self.Java_class.create(ctor: Self.Java_constructor_methodID, options: [], args: [])
+                    return JObject(ptr)
+                }
+            }
+            nonisolated private static let Java_constructor_methodID = Java_class.getMethodID(name: "<init>", sig: "()V")!
+            nonisolated public static func fromJavaObject(_ obj: JavaObjectPointer?, options: JConvertibleOptions) -> Self {
+                return .init(Java_ptr: obj!)
+            }
+            nonisolated public func toJavaObject(options: JConvertibleOptions) -> JavaObjectPointer? {
+                return Java_peer.safePointer()
+            }
+        }
+        @_cdecl("Java_Decoder_Swift_1projectionImpl")
+        public func Decoder_Swift_projectionImpl(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ options: Int32) -> JavaObjectPointer {
+            let projection = Decoder.fromJavaObject(Java_target, options: JConvertibleOptions(rawValue: Int(options)))
+            let factory: () -> Any = { projection }
+            return SwiftClosure0.javaObject(for: factory, options: [])!
+        }
+        """, transformers: transformers)
+    }
 }


### PR DESCRIPTION
## Motivation

A generic `@inline(__always)` function on a bridged type is emitted as a Kotlin `inline fun <reified T>`, which has **no JVM-callable method**. The bridge generator nonetheless emits a `getMethodID(...)!` / `getStaticMethodID(...)!` JNI lookup for it, so the force-unwrap traps at class load — `Fatal error: Unexpectedly found nil while unwrapping an Optional value` — for any native-Swift-on-Android caller (a `#if !SKIP_BRIDGE` app type calling through the real JNI edge; `swift test`'s JVM-native path never trips it because it inlines the body).

It reproduces whenever the reified method lives on an `open` class that has a subclass: the method is then lifted to a top-level `inline fun <reified T>` **extension** and bridged via `getStaticMethodID`. This is the root cause behind skiptools/skip-firebase#81 (originally worked around by switching a manual `// SKIP DECLARE: inline fun <reified T>` to `@inline(__always)`) and the still-open skiptools/skip-firebase#91, where `DocumentSnapshot.decoded()` (it has subclass `QueryDocumentSnapshot`) crashes again while the subclass-free `FirestoreDecoder` keeps working.

## Fix

In `KotlinFunctionDeclaration.checkBridgable(...) -> FunctionBridgable?`, return `nil` for a generic `@inline(__always)` function so it is not JNI-bridged. Native-Swift callers use the `@inline(__always)` Swift body directly (inlined); Kotlin callers use the `inline fun <reified T>`. An inline reified function was never JNI-callable to begin with, so nothing is lost — the change only removes a lookup that could only ever trap.

```swift
// A generic `@inline(__always)` function is emitted as a Kotlin `inline fun <reified T>` ...
// An inline reified function has no JVM-callable method, so a JNI getMethodID lookup for it
// returns nil and the generated bridge's force-unwrap traps at class load ...
guard !(attributes.contains(.inlineAlways) && !generics.isEmpty) else {
    return nil
}
```

## Also covers the manual `// SKIP DECLARE:` path (second commit)

A hand-written `// SKIP DECLARE: ... inline fun <reified T> ...` produces the same JVM-uncallable Kotlin but carries no structured attribute — so the attribute guard alone does **not** fully close #91. `DocumentSnapshot.decoded()` (now un-bridged by the attribute guard) inlines a call to `FirestoreDecoder.decode(from:)`, which uses exactly this override and is still emitting a trapping `getMethodID(name: "decode", ...)!` in a real build artifact — the crash reproduces one frame deeper. The second commit therefore also bails out of bridging when the declaration override is itself an inline reified function. (Currently a textual match on the override — happy to switch to a more structured signal if you'd prefer.)

## Testing

- `BridgeInlineReifiedTests` has two cases, both asserting the generated bridge contains the Kotlin `inline fun <reified T>` but **no** methodID lookup for the method: `testReifiedInlineMethodIsNotBridged` (the `@inline(__always)` path, #91 shape on an `open` class with a subclass) and `testSkipDeclareReifiedMethodIsNotBridged` (the `// SKIP DECLARE:` path, skip-firebase's `FirestoreDecoder.decode(from:)` shape).
- Full `swift test` suite green (922 tests, 0 failures).

Refs skiptools/skip-firebase#81, skiptools/skip-firebase#91
