### PR TITLE
Apply spread operator when delegating variadic static funcs to companion

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinStatementTypes.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinStatementTypes.swift
@@ -2156,10 +2156,14 @@ final class KotlinFunctionDeclaration: KotlinStatement, KotlinMemberDeclaration 
             if i > 0 {
                 output.append(", ")
             }
+            // Variadic parameters are declared as `vararg` and must be forwarded
+            // to the companion implementation with the spread ("*") operator, else
+            // Kotlin sees the Array type rather than the individual elements.
+            let spread = parameter.isVariadic ? "*" : ""
             if let label = parameter.externalLabel {
-                output.append(label).append(" = ").append(label)
+                output.append(label).append(" = ").append(spread).append(label)
             } else {
-                output.append(parameter.internalLabel)
+                output.append(spread).append(parameter.internalLabel)
             }
         }
         output.append(")\n")

--- a/Tests/SkipSyntaxTests/StaticTests.swift
+++ b/Tests/SkipSyntaxTests/StaticTests.swift
@@ -733,6 +733,34 @@ final class StaticTests: XCTestCase {
         """)
     }
 
+    func testStaticVariadicSpread() async throws {
+        // A static function with a variadic parameter delegates to its companion
+        // implementation, which must forward the parameter with the spread ("*")
+        // operator; otherwise Kotlin sees the Array type and fails to compile.
+        try await check(swift: """
+        public class A {
+            public static func initBridge(context: Int, _ libraryNames: String...) {
+            }
+            public static func withLabel(names labels: Int...) {
+            }
+        }
+        """, kotlin: """
+        import skip.lib.Array
+
+        open class A {
+
+            companion object: CompanionClass() {
+                override fun initBridge(context: Int, vararg libraryNames: String) = Unit
+                override fun withLabel(vararg names: Int) = Unit
+            }
+            open class CompanionClass {
+                open fun initBridge(context: Int, vararg libraryNames: String) = A.initBridge(context = context, *libraryNames)
+                open fun withLabel(vararg names: Int) = A.withLabel(names = *names)
+            }
+        }
+        """)
+    }
+
     private func codebaseInfo(moduleName: String, swift: String) throws -> CodebaseInfo {
         let srcFile = try tmpFile(named: "Source_\(moduleName).swift", contents: swift)
         let source = Source(file: Source.FilePath(path: srcFile.path), content: swift)


### PR DESCRIPTION
## Motivation

When a `public`/`internal` static function has a variadic parameter, the generated companion delegation drops the spread operator, producing uncompilable Kotlin (issue #64):

```
Argument type mismatch: actual type is 'kotlin.Array<CapturedType(out kotlin.String)>', but 'kotlin.String' was expected.
```

## Root cause

A static function is transpiled to an `override` on the type's `companion object` plus a delegating `open fun` on the inner `CompanionClass` that calls back into the concrete implementation. Both are declared with `vararg`, but `appendCompanionClassDelegatingMember` (`KotlinStatementTypes.swift`) forwarded each argument by bare name. Inside the delegate a `vararg` parameter has its `Array` type, so the call needs the spread (`*`) operator.

Before:

```kotlin
open fun initBridge(context: Int, vararg libraryNames: String) = A.initBridge(context = context, libraryNames)
```

After:

```kotlin
open fun initBridge(context: Int, vararg libraryNames: String) = A.initBridge(context = context, *libraryNames)
```

## Fix

Prefix the forwarded argument with `*` when the parameter is variadic — for both the unlabeled (`*libraryNames`) and labeled (`names = *names`) argument forms.

## Testing

- New `StaticTests.testStaticVariadicSpread` asserts the spread is emitted for both the unlabeled and labeled variadic forms (byte-for-byte against the generated Kotlin).
- Full `swift test` suite green (923 tests, 0 failures).
