### PR TITLE
Escape invalid characters in file-derived bridge function names

### DIFF
--- a/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
+++ b/Sources/SkipSyntax/Kotlin/KotlinBridgeTransformer.swift
@@ -223,8 +223,12 @@ struct CDeclFunction {
         } else {
             var file = translator.syntaxTree.source.file
             file.extension = ""
-            typeName = file.name + "Kt"
-            cdeclTypeName = typeName
+            // The JNI symbol side (`cdeclTypeName`) is escaped via `cdeclEscaped` at
+            // the return below. The Swift-identifier side (`typeName`) must be escaped
+            // here too, since a file name like `Foo+Bar.swift` yields `Foo+BarKt`, and
+            // the raw `+` produces an invalid Swift function name (issue #63).
+            cdeclTypeName = file.name + "Kt"
+            typeName = cdeclTypeName.cdeclEscaped
         }
         return (cdeclPrefix + cdeclTypeName.cdeclEscaped + "_" + name.cdeclEscaped, typeName + "_" + name)
     }

--- a/Tests/SkipSyntaxTests/FileNameEscapeTests.swift
+++ b/Tests/SkipSyntaxTests/FileNameEscapeTests.swift
@@ -1,0 +1,40 @@
+// Copyright (c) 2023 - 2026 Skip
+// Licensed under the GNU Affero General Public License v3.0
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import SkipSyntax
+import XCTest
+
+final class FileNameEscapeTests: XCTestCase {
+    private var transformers: [KotlinTransformer] {
+        return builtinKotlinTransformers() + [KotlinBridgeTransformer()]
+    }
+
+    // A source file whose name contains characters that are invalid in a Swift
+    // identifier (e.g. the "+" in `Model+Bridging.swift`) is used to derive both
+    // the JNI symbol (already escaped) and the generated `@_cdecl` Swift function
+    // name. The Swift-identifier side must be escaped too, or the generated
+    // bridging code fails to compile (issue #63).
+    func testBridgeFunctionNameEscapesInvalidFileNameCharacters() async throws {
+        try await check(swiftBridge: """
+        public var i = 1
+        """, swiftBridgeFileName: "Model+Bridging.swift", kotlin: """
+        var i: Int
+            get() = Swift_i()
+            set(newValue) {
+                Swift_i_set(newValue)
+            }
+        private external fun Swift_i(): Int
+        private external fun Swift_i_set(value: Int)
+        """, swiftBridgeSupport: """
+        @_cdecl("Java_Model_0002bBridgingKt_Swift_1i")
+        public func Model_0002bBridgingKt_Swift_i(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer) -> Int32 {
+            return Int32(i)
+        }
+        @_cdecl("Java_Model_0002bBridgingKt_Swift_1i_1set")
+        public func Model_0002bBridgingKt_Swift_i_set(_ Java_env: JNIEnvPointer, _ Java_target: JavaObjectPointer, _ value: Int32) {
+            i = Int(value)
+        }
+        """, transformers: transformers)
+    }
+}

--- a/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
+++ b/Tests/SkipSyntaxTests/XCTestCaseAdditions.swift
@@ -32,7 +32,7 @@ extension XCTestCase {
     ///   - swiftBridgeSupports: multiple expected bridging swift outputs
     ///   - file: the file of the call site, expected to be `#file`
     ///   - line: the line of the call site, expected to be `#line`
-    public func check(expectFailure: Bool = false, expectMessages: Bool = false, compiler: String? = ProcessInfo.processInfo.environment["KOTLINC"], dependentModules: [CodebaseInfo.ModuleExport] = [], supportingSwift: String? = nil, swift: StaticString? = nil, swiftCode: (() throws -> String?)? = nil, swiftBridge: String? = nil, kotlin: String? = nil, kotlins: [String] = [], fixup fixupKotlinBlock: ((String) -> (String)) = { $0 }, kotlinPackageSupport: String? = nil, swiftBridgeSupport: String? = nil, swiftBridgeSupports: [String] = [], bridgeDecodeLevel: DecodeLevel = .api, preprocessorSymbols: Set<String> = [], transformers: [KotlinTransformer] = builtinKotlinTransformers(), file: StaticString = #file, line: UInt = #line) async throws {
+    public func check(expectFailure: Bool = false, expectMessages: Bool = false, compiler: String? = ProcessInfo.processInfo.environment["KOTLINC"], dependentModules: [CodebaseInfo.ModuleExport] = [], supportingSwift: String? = nil, swift: StaticString? = nil, swiftCode: (() throws -> String?)? = nil, swiftBridge: String? = nil, swiftBridgeFileName: String = "Bridge.swift", kotlin: String? = nil, kotlins: [String] = [], fixup fixupKotlinBlock: ((String) -> (String)) = { $0 }, kotlinPackageSupport: String? = nil, swiftBridgeSupport: String? = nil, swiftBridgeSupports: [String] = [], bridgeDecodeLevel: DecodeLevel = .api, preprocessorSymbols: Set<String> = [], transformers: [KotlinTransformer] = builtinKotlinTransformers(), file: StaticString = #file, line: UInt = #line) async throws {
 
         func fixup(code: String) -> String {
             var code = fixupKotlinBlock(code)
@@ -93,7 +93,7 @@ extension XCTestCase {
         }
         var bridgeFiles: [Source.FilePath] = []
         if !swiftBridgeString.isEmpty {
-            let srcFile = try tmpFile(named: "Bridge.swift", contents: swiftBridgeString)
+            let srcFile = try tmpFile(named: swiftBridgeFileName, contents: swiftBridgeString)
             bridgeFiles.append(Source.FilePath(path: srcFile.path))
         }
         if let supportingSwift, !supportingSwift.isEmpty {


### PR DESCRIPTION
## Motivation

A bridged Swift file with no owning type derives its `@_cdecl` bridging symbol from the file name. When the file name contains a character that is invalid in a Swift identifier — the canonical case being a `+` in an extension file like `Model+Bridging.swift` — the generated Swift code fails to compile (issue #63):

```
error: expected '(' in argument list of function declaration
func Model+BridgingKt_Swift_i(_ Java_env: JNIEnvPointer, ...) { ... }
```

## Root cause

In `CDeclFunction.declaration` (`KotlinBridgeTransformer.swift`), the file-name branch builds one `typeName` (`<FileName>Kt`) used for **both** return values:

- the JNI symbol string — escaped via `.cdeclEscaped` (`+` → `_0002b`), so it was already correct;
- the generated Swift function name — used **raw**, so the `+` leaked through.

## Fix

Decouple the two: keep the raw name for the JNI-symbol computation, and escape the file-derived name for the Swift identifier using the same JNI-style codepoint escaping the symbol side already uses. The generated function becomes `Model_0002bBridgingKt_Swift_i`, consistent with its `@_cdecl("Java_Model_0002bBridgingKt_Swift_1i")` symbol.

Only the type-name portion (file-derived) is escaped; parameter/member names, which originate from valid Swift declarations, are untouched. The class-owned branch is unchanged.

## Testing

- New `FileNameEscapeTests.testBridgeFunctionNameEscapesInvalidFileNameCharacters` bridges a `public var` from a `Model+Bridging.swift` source and asserts (byte-for-byte) that both the Kotlin `external fun` side and the generated Swift `@_cdecl` side are well-formed.
- Added a small `swiftBridgeFileName` parameter to the shared `check` test helper (default `"Bridge.swift"`) so a bridge file name can be specified; no existing test behavior changes.
- Full `swift test` suite green (921 tests, 0 failures).
