### PR TITLE
Declare Android host triples in skip-linux artifactbundle supportedTriples

### DIFF
--- a/scripts/build_linux_plugin.sh
+++ b/scripts/build_linux_plugin.sh
@@ -94,14 +94,16 @@ chmod +x ${BINDIR}/${TOOLNAME}
 VARIANTS=""
 for ARCH in "${ARCHS[@]}"; do
     SDK="${ARCH}-swift-linux-musl"
-    TRIPLE="${ARCH}-unknown-linux-gnu"
+    # the static-MUSL binary also runs on Android (bionic) hosts, so
+    # declare the Android host triples as well (os(Android) != os(Linux))
+    TRIPLES="\"${ARCH}-unknown-linux-gnu\", \"${ARCH}-unknown-linux-android\", \"${ARCH}-unknown-linux-android24\""
     if [[ -n "${VARIANTS}" ]]; then
         VARIANTS="${VARIANTS},"
     fi
     VARIANTS="${VARIANTS}
             {
                 \"path\": \"${SDK}/${SKIPCMD}\",
-                \"supportedTriples\": [\"${TRIPLE}\"]
+                \"supportedTriples\": [${TRIPLES}]
             }"
 done
 


### PR DESCRIPTION
## Problem

The release-built `skip-linux.zip` artifactbundle declares only `*-unknown-linux-gnu` in each variant's `supportedTriples` (generated here in `build_linux_plugin.sh`). The static-MUSL `skip` binary itself runs fine on Android (bionic) hosts — verified on-device (aarch64 Termux, Swift 6.3.2 Android toolchain) — but SwiftPM rejects the binary target there with "Tool 'skip' is not supported on the target platform" because the host triple (`aarch64-unknown-linux-android24`) isn't listed.

Together with https://github.com/skiptools/skip/pull/725 (which makes the manifest select the Linux binary target for `os(Android)` hosts), this lets Android hosts use the prebuilt transpiler instead of building skipstone + SwiftSyntax from source — a host build that spikes 5–8 GB RSS per swift-frontend process and OOM-kills typical Android devices.

## Change

Add `<arch>-unknown-linux-android` and `<arch>-unknown-linux-android24` to `supportedTriples` for each built arch. No binary changes; the triples are only host-platform declarations for SwiftPM's artifact selection. (API 24 matches the swift.org Android toolchain's host triple; the generic `-android` triple covers other Android environments.)

## Testing

Validated the generated `info.json` syntax by simulating the VARIANTS loop; verified end-to-end earlier by repacking the published 1.9.5 `skip-linux.zip` with these triples added — SwiftPM on-device then accepts the binary target and skipstone/SwiftSyntax leave the dependency graph entirely.